### PR TITLE
fix: added a 'ignore list' of transactions including the genesis txs

### DIFF
--- a/DATABASE.md
+++ b/DATABASE.md
@@ -145,3 +145,34 @@ CREATE TABLE `wallet_tx_history` (
   PRIMARY KEY (`wallet_id`,`token_id`,`tx_id`)
 );
 ```
+
+# Genesis transactions
+
+We need to add the genesis transactions to the database as the service expects to already have them.
+
+## Mainnet
+```
+INSERT INTO `metadata` (`key`, `value`) VALUES ('height', 0);
+INSERT INTO `blocks` (`tx_id`, `height`) VALUES ('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc', 0);
+INSERT INTO `utxo` (`tx_id`, `index`, `token_id`, `address`, `value`)
+     VALUES ('000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc',
+              0,
+              '00',
+              'HJB2yxxsHtudGGy3jmVeadwMfRi2zNCKKD',
+              100000000000
+              );
+```
+
+## Testnet
+
+```
+INSERT INTO `metadata` (`key`, `value`) VALUES ('height', 0);
+INSERT INTO `blocks` (`tx_id`, `height`) VALUES ('0000033139d08176d1051fb3a272c3610457f0c7f686afbe0afe3d37f966db85', 0);
+INSERT INTO `utxo` (`tx_id`, `index`, `token_id`, `address`, `value`)
+     VALUES ('0000033139d08176d1051fb3a272c3610457f0c7f686afbe0afe3d37f966db85',
+              0,
+              '00',
+              'WdmDUMp8KvzhWB7KLgguA2wBiKsh4Ha8eX',
+              100000000000
+              );
+```

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -98,7 +98,8 @@ const addNewTx = async (tx: Transaction, now: number, blockRewardLock: number) =
   const txId = tx.tx_id;
   const network = process.env.NETWORK;
 
-  // we should ignore genesis transactions as they have no parents, inputs and outputs
+  // we should ignore genesis transactions as they have no parents, inputs and outputs and we expect the service
+  // to already have the pre-mine utxos on its database.
   if (network in IGNORE_TXS) {
     if (IGNORE_TXS[network].includes(txId)) {
       throw new Error('Rejecting tx as it is part of the genesis transactions.');

--- a/tests/txProcessor.test.ts
+++ b/tests/txProcessor.test.ts
@@ -105,6 +105,45 @@ test('spend "locked" utxo', async () => {
   await expect(checkWalletBalanceTable(mysql, 1, walletId, token, 2000, 0, null, 2)).resolves.toBe(true);
 });
 
+test('Genesis transactions should throw', async () => {
+  expect.hasAssertions();
+
+  const evt = JSON.parse(JSON.stringify(eventTemplate));
+  const tx = evt.Records[0].body;
+
+  tx.inputs = [];
+  tx.outputs = [];
+  tx.parents = [];
+
+  process.env.NETWORK = 'mainnet';
+
+  tx.tx_id = txProcessor.IGNORE_TXS.mainnet[0];
+
+  await expect(() => txProcessor.onNewTxEvent(evt)).rejects.toThrow('Rejecting tx as it is part of the genesis transactions.');
+
+  tx.tx_id = txProcessor.IGNORE_TXS.mainnet[1];
+
+  await expect(() => txProcessor.onNewTxEvent(evt)).rejects.toThrow('Rejecting tx as it is part of the genesis transactions.');
+
+  tx.tx_id = txProcessor.IGNORE_TXS.mainnet[2];
+
+  await expect(() => txProcessor.onNewTxEvent(evt)).rejects.toThrow('Rejecting tx as it is part of the genesis transactions.');
+
+  process.env.NETWORK = 'testnet';
+
+  tx.tx_id = txProcessor.IGNORE_TXS.testnet[0];
+
+  await expect(() => txProcessor.onNewTxEvent(evt)).rejects.toThrow('Rejecting tx as it is part of the genesis transactions.');
+
+  tx.tx_id = txProcessor.IGNORE_TXS.testnet[1];
+
+  await expect(() => txProcessor.onNewTxEvent(evt)).rejects.toThrow('Rejecting tx as it is part of the genesis transactions.');
+
+  tx.tx_id = txProcessor.IGNORE_TXS.testnet[2];
+
+  await expect(() => txProcessor.onNewTxEvent(evt)).rejects.toThrow('Rejecting tx as it is part of the genesis transactions.');
+});
+
 /*
  * receive some transactions and blocks and make sure database is correct
  */


### PR DESCRIPTION
We could extend this to ignore other transactions, maybe have a list of transactions to ignore on an env variable but I think that this should be enough for the transactions on the `testnet` and `mainnet` as they won't ever change