### PR TITLE
chore: increased timeout on handleReorgRequest route

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -63,6 +63,7 @@ functions:
     handler: src/txProcessor.onNewTxRequest
   onHandleReorgRequest:
     handler: src/txProcessor.onHandleReorgRequest
+    timeout: 300 # 5 minutes
   onSearchForLatestValidBlockRequest:
     handler: src/txProcessor.onSearchForLatestValidBlockRequest
   onNewTxEvent:


### PR DESCRIPTION
The default timeout is 6 seconds and reorgs (even 1 block reorgs) take at least 12 seconds to run, so the daemon received an error from the wallet-service and transitioned to the `failure` state.

I've increased it to 5 minutes, I believe that it is more than enough because the part that is taking more time is the best block binary search and that should take the same time for every reorg size