### PR TITLE
chore: added an arn to allow the loadWallet lambda to invoke loadWall…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -71,6 +71,7 @@ functions:
   loadWalletAsync:
     handler: src/api/wallet.loadWallet
   loadWalletApi:
+    role: arn:aws:iam::769498303037:role/WalletServiceLoadWalletLambda
     handler: src/api/wallet.load
     events:
       - http:


### PR DESCRIPTION
This is necessary so the `loadWallet` can invoke `loadWalletAsync`.

There is no support for creating the role on `serverless.yml` yet, so @luislhl created it manually through AWS and we are configuring the ARN on serverless.yml