### PR TITLE
fix(auth): policy generated

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -74,14 +74,14 @@ functions:
     handler: src/api/wallet.load
     events:
       - http:
-          path: wallet
+          path: wallet/init
           method: post
           cors: true
   getWalletStatusApi:
     handler: src/api/wallet.get
     events:
       - http:
-          path: wallet
+          path: wallet/status
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
@@ -89,7 +89,7 @@ functions:
     handler: src/api/addresses.get
     events:
       - http:
-          path: addresses
+          path: wallet/addresses
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
@@ -97,7 +97,7 @@ functions:
     handler: src/api/balances.get
     events:
       - http:
-          path: balances
+          path: wallet/balances
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
@@ -105,7 +105,7 @@ functions:
     handler: src/api/txhistory.get
     events:
       - http:
-          path: txhistory
+          path: wallet/history
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
@@ -113,7 +113,7 @@ functions:
     handler: src/api/txProposalCreate.create
     events:
       - http:
-          path: txproposals
+          path: tx/proposal
           method: post
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
@@ -121,7 +121,7 @@ functions:
     handler: src/api/txProposalSend.send
     events:
       - http:
-          path: txproposals/{txProposalId}
+          path: tx/proposal/{txProposalId}
           method: put
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
@@ -133,7 +133,7 @@ functions:
     handler: src/api/txProposalDestroy.destroy
     events:
       - http:
-          path: txproposals/{txProposalId}
+          path: tx/proposal/{txProposalId}
           method: delete
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -150,6 +150,7 @@ export const tokenHandler: APIGatewayProxyHandler = async (event) => {
  * Generates a aws policy document to allow/deny access to the resource
  */
 const _generatePolicy = (principalId: string, effect: string, resource: string) => {
+  const resourcePrefix = `${resource.split('/').slice(0, 2).join('/')}/*`;
   const policyDocument: PolicyDocument = {
     Version: '2012-10-17',
     Statement: [],
@@ -158,7 +159,10 @@ const _generatePolicy = (principalId: string, effect: string, resource: string) 
   const statementOne: Statement = {
     Action: 'execute-api:Invoke',
     Effect: effect,
-    Resource: resource,
+    Resource: [
+      `${resourcePrefix}/wallet/*`,
+      `${resourcePrefix}/tx/*`,
+    ],
   };
 
   policyDocument.Statement[0] = statementOne;
@@ -171,6 +175,8 @@ const _generatePolicy = (principalId: string, effect: string, resource: string) 
   const context = { walletId: principalId };
   authResponse.context = context;
 
+  // XXX: to get the resulting policy on the logs, since we can't check the cached policy
+  console.info('Generated policy:', authResponse);
   return authResponse;
 };
 


### PR DESCRIPTION
ARN of API Gateway resource: `arn:aws:execute-api:<region>:<account>:<project>/<stage>/<http-method>/<path>`
(Any path parameter is a `*`)

When a user authenticates with his wallet he should receive permission to access the `/wallet/*` and `/tx/*` instead of the resource he currently is accessing. 