### PR TITLE
feat: wallet tokens api

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -148,6 +148,14 @@ functions:
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
+  getTokensApi:
+    handler: src/api/tokens.get
+    events:
+      - http:
+          path: wallet/tokens
+          method: get
+          cors: true
+          authorizer: ${self:custom.authorizer.walletBearer}
   getTxHistoryApi:
     handler: src/api/txhistory.get
     events:

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -1,0 +1,24 @@
+import 'source-map-support/register';
+
+import { walletIdProxyHandler } from '@src/commons';
+import { getWalletTokens } from '@src/db';
+import { getDbConnection } from '@src/utils';
+
+const mysql = getDbConnection();
+
+/*
+ * List wallet tokens
+ *
+ * This lambda is called by API Gateway on GET /wallet/tokens
+ */
+export const get = walletIdProxyHandler(async (walletId) => {
+  const walletTokens: string[] = await getWalletTokens(mysql, walletId);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify({
+      success: true,
+      tokens: walletTokens,
+    }),
+  };
+});

--- a/src/db.ts
+++ b/src/db.ts
@@ -1188,6 +1188,30 @@ export const getWalletBalances = async (mysql: ServerlessMysql, walletId: string
 };
 
 /**
+ * Gets a list of tokens that a given walllet has ever interacted with
+ *
+ * @returns A list of tokens.
+ */
+export const getWalletTokens = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+): Promise<string[]> => {
+  const tokenList: string[] = [];
+  const results: DbSelectResult = await mysql.query(
+    `SELECT DISTINCT(token_id)
+       FROM \`wallet_tx_history\`
+      WHERE \`wallet_id\` = ?`,
+    [walletId],
+  );
+
+  for (const result of results) {
+    tokenList.push(<string> result.token_id);
+  }
+
+  return tokenList;
+};
+
+/**
  * Get a wallet's transaction history for a token.
  *
  * @remarks
@@ -1226,6 +1250,7 @@ export const getWalletTxHistory = async (
     const tx: TxTokenBalance = {
       txId: <string>result.tx_id,
       timestamp: <number>result.timestamp,
+      voided: <boolean>result.voided,
       balance: <Balance>result.balance,
     };
     history.push(tx);

--- a/src/db.ts
+++ b/src/db.ts
@@ -1188,7 +1188,7 @@ export const getWalletBalances = async (mysql: ServerlessMysql, walletId: string
 };
 
 /**
- * Gets a list of tokens that a given walllet has ever interacted with
+ * Gets a list of tokens that a given wallet has ever interacted with
  *
  * @returns A list of tokens.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,6 +348,7 @@ export class WalletTokenBalance {
 export interface TxTokenBalance {
   txId: string;
   timestamp: number;
+  voided?: boolean | null;
   balance: Balance;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,7 +348,7 @@ export class WalletTokenBalance {
 export interface TxTokenBalance {
   txId: string;
   timestamp: number;
-  voided?: boolean | null;
+  voided: boolean;
   balance: Balance;
 }
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -18,6 +18,7 @@ import {
   getWallet,
   getWalletAddressDetail,
   getWalletAddresses,
+  getWalletTokens,
   getWalletBalances,
   getWalletSortedValueUtxos,
   getVersionData,
@@ -77,6 +78,7 @@ import {
   addToTokenTable,
   addToUtxoTable,
   addToWalletBalanceTable,
+  addToWalletTxHistoryTable,
   addToWalletTable,
   cleanDatabase,
   checkAddressBalanceTable,
@@ -691,6 +693,28 @@ test('updateAddressTablesWithTx', async () => {
   };
   await updateAddressTablesWithTx(mysql, txId5, timestamp5, addrMap5);
   await expect(checkAddressBalanceTable(mysql, 5, address1, 'token1', 5, 7, lockExpires - 1, 5)).resolves.toBe(true);
+});
+
+test('getWalletTokens', async () => {
+  expect.hasAssertions();
+  const wallet1 = 'wallet1';
+  const wallet2 = 'wallet2';
+
+  await addToWalletTxHistoryTable(mysql, [
+    [wallet1, 'tx1', '00', 5, 1000, false],
+    [wallet1, 'tx1', 'token2', 70, 1000, false],
+    [wallet1, 'tx2', 'token3', 10, 1001, false],
+    [wallet1, 'tx3', 'token4', 25, 1001, false],
+    [wallet1, 'tx4', 'token2', 30, 1001, false],
+    [wallet2, 'tx5', '00', 35, 1001, false],
+    [wallet2, 'tx6', 'token2', 31, 1001, false],
+  ]);
+
+  const wallet1Tokens = await getWalletTokens(mysql, wallet1);
+  const wallet2Tokens = await getWalletTokens(mysql, wallet2);
+
+  expect(wallet1Tokens).toHaveLength(4);
+  expect(wallet2Tokens).toHaveLength(2);
 });
 
 test('getWalletAddresses', async () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -522,7 +522,7 @@ export const addToWalletTxHistoryTable = async (
   await mysql.query(`
     INSERT INTO \`wallet_tx_history\`(\`wallet_id\`, \`tx_id\`,
                                       \`token_id\`, \`balance\`,
-                                      \`timestamp\`)
+                                      \`timestamp\`, \`voided\`)
     VALUES ?`,
   [entries]);
 };


### PR DESCRIPTION
This was a request from @pedroferreira1 so he can be able to list all tokens a wallet has using the wallet-lib without needing to fetch the full wallet tx history.

