### PR TITLE
refactor: getLatestHeight now uses LIMIT 1 to get the latest block

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1357,10 +1357,13 @@ export const getVersionData = async (mysql: ServerlessMysql): Promise<FullNodeVe
  */
 export const getLatestHeight = async (mysql: ServerlessMysql): Promise<number> => {
   const results: DbSelectResult = await mysql.query(
-    `SELECT MAX(\`height\`) AS value
+    `SELECT \`height\` AS value
        FROM \`transaction\`
       WHERE version
-         IN (?)`, [BLOCK_VERSION],
+         IN (?)
+      ORDER BY height
+       DESC
+      LIMIT 1`, [BLOCK_VERSION],
   );
 
   if (results.length > 0) {


### PR DESCRIPTION
## Motivation

We have an index on `height` that was not in use with `MAX(height)`:

```sql
MySQL [hathor_wallet_service]> explain SELECT MAX(`height`) AS value        FROM `transaction`       WHERE version          IN (0, 3);
+----+-------------+-------------+------------+------+-------------------------+------+---------+------+---------+----------+-------------+
| id | select_type | table       | partitions | type | possible_keys           | key  | key_len | ref  | rows    | filtered | Extra       |
+----+-------------+-------------+------------+------+-------------------------+------+---------+------+---------+----------+-------------+
|  1 | SIMPLE      | transaction | NULL       | ALL  | transaction_version_idx | NULL | NULL    | NULL | 1741654 |    56.90 | Using where |
+----+-------------+-------------+------------+------+-------------------------+------+---------+------+---------+----------+-------------+
1 row in set, 1 warning (0.228 sec)
```

You can see in the `key` column that the index is not in use

Using `LIMIT 1` it uses the index properly and the query gets almost 30 times faster as expected:

```sql
MySQL [hathor_wallet_service]> explain SELECT height FROM `transaction` WHERE version IN (0, 3) ORDER BY height DESC LIMIT 1;
+----+-------------+-------------+------------+-------+-------------------------+------------------------+---------+------+------+----------+----------------------------------+
| id | select_type | table       | partitions | type  | possible_keys           | key                    | key_len | ref  | rows | filtered | Extra                            |
+----+-------------+-------------+------------+-------+-------------------------+------------------------+---------+------+------+----------+----------------------------------+
|  1 | SIMPLE      | transaction | NULL       | index | transaction_version_idx | transaction_height_idx | 5       | NULL |    1 |    56.90 | Using where; Backward index scan |
+----+-------------+-------------+------------+-------+-------------------------+------------------------+---------+------+------+----------+----------------------------------+
```


Results:
```sql
MySQL [hathor_wallet_service]> SELECT MAX(`height`) AS value FROM `transaction` WHERE version IN (0, 3);
+---------+
| value   |
+---------+
| 1600746 |
+---------+
1 row in set (5.636 sec)
```

```sql
MySQL [hathor_wallet_service]> SELECT height FROM `transaction` WHERE version IN (0, 3) ORDER BY height DESC LIMIT 1;
+---------+
| height  |
+---------+
| 1600746 |
+---------+
1 row in set (0.207 sec)
```