### PR TITLE
fix: added address, address_balance and address_tx_history to seeders

### DIFF
--- a/db/seeders/mainnet.js
+++ b/db/seeders/mainnet.js
@@ -18,6 +18,28 @@ module.exports = {
           address: 'HJB2yxxsHtudGGy3jmVeadwMfRi2zNCKKD',
           value: 100000000000,
         }], { transaction: t }),
+        queryInterface.bulkInsert('address', [{
+          address: 'HJB2yxxsHtudGGy3jmVeadwMfRi2zNCKKD',
+          transactions: 1,
+        }], { transaction: t }),
+        queryInterface.bulkInsert('address_balance', [{
+          address: 'HJB2yxxsHtudGGy3jmVeadwMfRi2zNCKKD',
+          token_id: '00',
+          unlocked_balance: 100000000000,
+          locked_balance: 0,
+          unlocked_authorities: 0,
+          locked_authorities: 0,
+          timelock_expires: 0,
+          transactions: 1,
+        }], { transaction: t }),
+        queryInterface.bulkInsert('address_tx_history', [{
+          address: 'HJB2yxxsHtudGGy3jmVeadwMfRi2zNCKKD',
+          tx_id: '000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc',
+          token_id: '00',
+          balance: 100000000000,
+          timestamp: 1578075305,
+          voided: false,
+        }], { transaction: t }),
       ]);
     });
   },
@@ -31,6 +53,18 @@ module.exports = {
         queryInterface.bulkDelete('tx_output', {
           tx_id: '000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc',
           index: 0,
+        }, { transaction: t }),
+        queryInterface.bulkDelete('address', {
+          address: 'HJB2yxxsHtudGGy3jmVeadwMfRi2zNCKKD',
+        }, { transaction: t }),
+        queryInterface.bulkDelete('address_balance', {
+          address: 'HJB2yxxsHtudGGy3jmVeadwMfRi2zNCKKD',
+          token: '00',
+        }, { transaction: t }),
+        queryInterface.bulkDelete('address_tx_history', {
+          address: 'HJB2yxxsHtudGGy3jmVeadwMfRi2zNCKKD',
+          tx_id: '000006cb93385b8b87a545a1cbb6197e6caff600c12cc12fc54250d39c8088fc',
+          token: '00',
         }, { transaction: t }),
       ]);
     });

--- a/db/seeders/testnet.js
+++ b/db/seeders/testnet.js
@@ -18,6 +18,28 @@ module.exports = {
           address: 'WdmDUMp8KvzhWB7KLgguA2wBiKsh4Ha8eX',
           value: 100000000000,
         }], { transaction: t }),
+        queryInterface.bulkInsert('address', [{
+          address: 'WdmDUMp8KvzhWB7KLgguA2wBiKsh4Ha8eX',
+          transactions: 1,
+        }], { transaction: t }),
+        queryInterface.bulkInsert('address_balance', [{
+          address: 'WdmDUMp8KvzhWB7KLgguA2wBiKsh4Ha8eX',
+          token_id: '00',
+          unlocked_balance: 100000000000,
+          locked_balance: 0,
+          unlocked_authorities: 0,
+          locked_authorities: 0,
+          timelock_expires: 0,
+          transactions: 1,
+        }], { transaction: t }),
+        queryInterface.bulkInsert('address_tx_history', [{
+          address: 'WdmDUMp8KvzhWB7KLgguA2wBiKsh4Ha8eX',
+          tx_id: '0000033139d08176d1051fb3a272c3610457f0c7f686afbe0afe3d37f966db85',
+          token_id: '00',
+          balance: 100000000000,
+          timestamp: 1577836800,
+          voided: false,
+        }], { transaction: t }),
       ]);
     });
   },
@@ -31,6 +53,18 @@ module.exports = {
         queryInterface.bulkDelete('tx_output', {
           tx_id: '0000033139d08176d1051fb3a272c3610457f0c7f686afbe0afe3d37f966db85',
           index: 0,
+        }, { transaction: t }),
+        queryInterface.bulkDelete('address', {
+          address: 'WdmDUMp8KvzhWB7KLgguA2wBiKsh4Ha8eX',
+        }, { transaction: t }),
+        queryInterface.bulkDelete('address_balance', {
+          address: 'WdmDUMp8KvzhWB7KLgguA2wBiKsh4Ha8eX',
+          token: '00',
+        }, { transaction: t }),
+        queryInterface.bulkDelete('address_tx_history', {
+          address: 'WdmDUMp8KvzhWB7KLgguA2wBiKsh4Ha8eX',
+          tx_id: '0000033139d08176d1051fb3a272c3610457f0c7f686afbe0afe3d37f966db85',
+          token: '00',
         }, { transaction: t }),
       ]);
     });


### PR DESCRIPTION
# Acceptance criteria

Sequelize seeders should insert the genesis `address`, `address_balance` and `address_tx_history` correctly on the database.