### PR TITLE
chore: remove unused function from serverless

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -100,8 +100,6 @@ functions:
   onHandleReorgRequest:
     handler: src/txProcessor.onHandleReorgRequest
     timeout: 300 # 5 minutes
-  onSearchForLatestValidBlockRequest:
-    handler: src/txProcessor.onSearchForLatestValidBlockRequest
   onNewTxEvent:
     handler: src/txProcessor.onNewTxEvent
   loadWalletAsync:


### PR DESCRIPTION
# Acceptance criteria

This function was not being used by any service. So all services (the daemon) that use the wallet service must continue working