### PR TITLE
chore: rename Lambda stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
-.PHONY: deploy-lambdas-dev
-deploy-lambdas-dev:
-	serverless deploy --stage dev --region eu-central-1
+.PHONY: deploy-lambdas-dev-testnet
+deploy-lambdas-dev-testnet:
+	serverless deploy --stage dev-testnet --region eu-central-1
 
-.PHONY: deploy-lambdas-prod
-deploy-lambdas-prod:
-	serverless deploy --stage prod --region eu-central-1
+.PHONY: deploy-lambdas-testnet
+deploy-lambdas-testnet:
+	serverless deploy --stage testnet --region eu-central-1
+
+.PHONY: deploy-lambdas-mainnet
+deploy-lambdas-mainnet:
+	serverless deploy --stage mainnet --region eu-central-1
 
 .PHONY: migrate
 migrate:


### PR DESCRIPTION
issue: issue: https://github.com/HathorNetwork/ops-tools/issues/119

### Acceptance Criteria
- We should have the `mainnet`, `testnet` and `dev-testnet` stages now
- We should have the domains `wallet-service.hathor.network`, `wallet-service.testnet.hathor.network` and `dev.wallet-service.testnet.hahor.network` pointing to the corresponding API Gateway (this is not included in this PR, since it was done manually in AWS)