### PR TITLE
chore: add prometheus metrics endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4104,6 +4104,11 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "bitcore-lib": {
       "version": "8.25.10",
       "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.25.10.tgz",
@@ -12892,6 +12897,14 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prom-client": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.2.0.tgz",
+      "integrity": "sha512-wGr5mlNNdRNzEhRYXgboUU2LxHWIojxscJKmtG3R8f4/KiWqyYgXTLHs0+Ted7tG3zFT7pgHJbtomzZ1L0ARaQ==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
+    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -15380,6 +15393,14 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
       }
     },
     "term-size": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jsonwebtoken": "^8.5.1",
     "mysql": "^2.18.1",
     "mysql2": "^2.2.5",
+    "prom-client": "^13.2.0",
     "redis": "^3.1.2",
     "sequelize": "^6.6.4",
     "serverless-mysql": "^1.5.4",

--- a/serverless.yml
+++ b/serverless.yml
@@ -63,7 +63,6 @@ provider:
     DB_NAME: ${env:DB_NAME}
     DB_USER: ${env:DB_USER}
     DB_PASS: ${env:DB_PASS}
-    ENVIRONMENT: ${opt:stage, 'dev'}
     SERVICE_NAME: ${self:service}
     MAX_ADDRESS_GAP: ${env:MAX_ADDRESS_GAP}
     NETWORK: ${env:NETWORK}

--- a/serverless.yml
+++ b/serverless.yml
@@ -63,13 +63,14 @@ provider:
     DB_NAME: ${env:DB_NAME}
     DB_USER: ${env:DB_USER}
     DB_PASS: ${env:DB_PASS}
-    SERVICE_NAME: ${self:service}
     MAX_ADDRESS_GAP: ${env:MAX_ADDRESS_GAP}
     NETWORK: ${env:NETWORK}
     NEW_TX_SQS: { Ref: WalletServiceNewTxQueue }
     REDIS_HOST: ${env:REDIS_HOST}
     REDIS_PORT: ${env:REDIS_PORT}
     REDIS_PASSWORD: ${env:REDIS_PASSWORD}
+    SERVICE_NAME: ${self:service}
+    STAGE: ${opt:stage, 'dev'}
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/serverless.yml
+++ b/serverless.yml
@@ -63,6 +63,7 @@ provider:
     DB_NAME: ${env:DB_NAME}
     DB_USER: ${env:DB_USER}
     DB_PASS: ${env:DB_PASS}
+    ENVIRONMENT: ${opt:stage, 'dev'}
     SERVICE_NAME: ${self:service}
     MAX_ADDRESS_GAP: ${env:MAX_ADDRESS_GAP}
     NETWORK: ${env:NETWORK}
@@ -236,3 +237,9 @@ functions:
           cors: true
   bearerAuthorizer:
     handler: src/api/auth.bearerAuthorizer
+  metrics:
+    handler: src/metrics.getMetrics
+    events:
+      - http:
+          path: metrics
+          method: get

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import prom_client from 'prom-client';
+import 'source-map-support/register';
+
+import { getLatestHeight } from '@src/db';
+import { closeDbConnection, getDbConnection } from '@src/utils';
+
+const mysql = getDbConnection();
+
+// Default labels
+const defaultLabels = {
+  network: process.env.NETWORK,
+  environment: process.env.ENVIRONMENT
+};
+prom_client.register.setDefaultLabels(defaultLabels);
+
+// Best block height metric
+new prom_client.Gauge({
+  name: 'wallet_service:best_block_height',
+  help: 'The height of the latest block received',
+  async collect() {
+    const height = await getLatestHeight(mysql);
+    this.set(height);
+  },
+});
+
+/*
+ * Returns all registered metrics in Prometheus format
+ *
+ * This lambda is called by API Gateway on GET /metrics
+ */
+export const getMetrics: APIGatewayProxyHandler = async () => {
+  const body = await prom_client.register.metrics();
+  await closeDbConnection(mysql);
+
+  return {
+    statusCode: 200,
+    body,
+  };
+};

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -17,7 +17,7 @@ const mysql = getDbConnection();
 // Default labels
 const defaultLabels = {
   network: process.env.NETWORK,
-  environment: process.env.ENVIRONMENT
+  environment: process.env.STAGE
 };
 prom_client.register.setDefaultLabels(defaultLabels);
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -6,7 +6,7 @@
  */
 
 import { APIGatewayProxyHandler } from 'aws-lambda';
-import prom_client from 'prom-client';
+import promClient from 'prom-client';
 import 'source-map-support/register';
 
 import { getLatestHeight } from '@src/db';
@@ -17,12 +17,12 @@ const mysql = getDbConnection();
 // Default labels
 const defaultLabels = {
   network: process.env.NETWORK,
-  environment: process.env.STAGE
+  environment: process.env.STAGE,
 };
-prom_client.register.setDefaultLabels(defaultLabels);
+promClient.register.setDefaultLabels(defaultLabels);
 
 // Best block height metric
-new prom_client.Gauge({
+new promClient.Gauge({  // eslint-disable-line no-new
   name: 'wallet_service:best_block_height',
   help: 'The height of the latest block received',
   async collect() {
@@ -37,7 +37,7 @@ new prom_client.Gauge({
  * This lambda is called by API Gateway on GET /metrics
  */
 export const getMetrics: APIGatewayProxyHandler = async () => {
-  const body = await prom_client.register.metrics();
+  const body = await promClient.register.metrics();
   await closeDbConnection(mysql);
 
   return {


### PR DESCRIPTION
### Aceptance Criteria
- There should be a new `/metrics` endpoint in API Gateway
- The new endpoint should return the metric `wallet_service:best_block_height` by making a query in the database

### Questions
- Should we have authentication in this endpoint?