### PR TITLE
refactor: remove unecessary outputs mapping on tx proposal create

### DIFF
--- a/src/api/txProposalCreate.ts
+++ b/src/api/txProposalCreate.ts
@@ -72,19 +72,6 @@ export const create = walletIdProxyHandler(async (walletId, event) => {
     return closeDbAndGetError(mysql, ApiError.TOO_MANY_OUTPUTS, { outputs: tx.outputs.length });
   }
 
-  const getToken = (tokenData, tokens) => {
-    if (tokenData === 0) {
-      return '00';
-    }
-
-    if (!tokenData) {
-      return null;
-    }
-
-    return tokens[hathorLib.wallet.getTokenIndex(tokenData) - 1];
-  };
-
-  const tokens = tx.tokens;
   const inputs: IWalletInput[] = tx.inputs.map((input) => ({
     txId: input.hash,
     index: input.index,
@@ -151,7 +138,6 @@ export const create = walletIdProxyHandler(async (walletId, event) => {
       success: true,
       txProposalId,
       inputs: retInputs,
-      tokens,
     }),
   };
 });

--- a/src/api/txProposalCreate.ts
+++ b/src/api/txProposalCreate.ts
@@ -22,7 +22,6 @@ import {
 import {
   AddressInfo,
   IWalletInput,
-  IWalletOutput,
   DbTxOutput,
 } from '@src/types';
 import { closeDbAndGetError } from '@src/api/utils';

--- a/src/api/txProposalCreate.ts
+++ b/src/api/txProposalCreate.ts
@@ -85,13 +85,6 @@ export const create = walletIdProxyHandler(async (walletId, event) => {
   };
 
   const tokens = tx.tokens;
-  const outputs: IWalletOutput[] = tx.outputs.map((output) => ({
-    address: output.address.base58,
-    value: output.value,
-    token: getToken(output.tokenData, tokens),
-    tokenData: output.tokenData,
-    timelock: output.timelock,
-  }));
   const inputs: IWalletInput[] = tx.inputs.map((input) => ({
     txId: input.hash,
     index: input.index,
@@ -158,7 +151,6 @@ export const create = walletIdProxyHandler(async (walletId, event) => {
       success: true,
       txProposalId,
       inputs: retInputs,
-      outputs,
       tokens,
     }),
   };

--- a/tests/txProposal.test.ts
+++ b/tests/txProposal.test.ts
@@ -142,14 +142,6 @@ test('POST /txproposals with utxos that are already used on another txproposal s
   expect(returnBody.txProposalId).toHaveLength(36);
   expect(returnBody.inputs).toHaveLength(1);
   expect(returnBody.inputs).toContainEqual({ txId: utxos[0][0], index: utxos[0][1], addressPath: `${defaultDerivationPath}0` });
-  expect(returnBody.outputs).toHaveLength(1);
-  expect(returnBody.outputs).toContainEqual({
-    address: outputs[0].address.base58,
-    value: outputs[0].value,
-    tokenData: 1,
-    token: token1,
-    timelock: null,
-  });
 
   // Send the same tx (same txHex) again
   const usedInputsEvent = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({ txHex }));
@@ -906,9 +898,6 @@ test('POST /txproposals one output and input on txHex', async () => {
   expect(returnBody.txProposalId).toHaveLength(36);
   expect(returnBody.inputs).toHaveLength(1);
   expect(returnBody.inputs).toContainEqual({ txId: utxos[0][0], index: utxos[0][1], addressPath: `${defaultDerivationPath}0` });
-  expect(returnBody.outputs).toHaveLength(1);
-  expect(returnBody.outputs).toContainEqual({ address: ADDRESSES[0], value: 300, token: token1, tokenData: 1, timelock: null });
-  expect(returnBody.tokens).toContainEqual(token1);
 
   await _checkTxProposalTables(returnBody.txProposalId, returnBody.inputs);
 });
@@ -1026,8 +1015,6 @@ test('POST /txproposals a tx create action on txHex', async () => {
   expect(returnBody.txProposalId).toHaveLength(36);
   expect(returnBody.inputs).toHaveLength(1);
   expect(returnBody.inputs).toContainEqual({ txId: utxos[0][0], index: utxos[0][1], addressPath: `${defaultDerivationPath}0` });
-  expect(returnBody.outputs).toHaveLength(4);
-  expect(returnBody.outputs).toContainEqual({ address: ADDRESSES[0], value: 200, token: '00', tokenData: 0, timelock: null });
 });
 
 test('PUT /txproposals/{proposalId} with txhex', async () => {


### PR DESCRIPTION
The NFT integration in the wallet lib create another output type and the tx proposal create code was mapping the tx outputs to a p2pkh object. 

I could refactor this method to create a specific method for each output type (we also have now in the output object a `parsedScript` attribute) but this mapping is not needed. It was basically parsing and returning an array of outputs that was just sent to the wallet service, so the sender already has all the information in the response.

That's why I decided to just remove this response key instead of refactor it to make it work with all output types.

### Acceptance criteria

- Tx proposal create and send must work with an NFT transaction