### PR TITLE
fix: handling nft outputs on the wallet-service instead of the daemon

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -509,9 +509,8 @@ export const walletIdProxyHandler = (handler: WalletProxyHandler): APIGatewayPro
 );
 
 export const prepareOutputs = (outputs: TxOutput[], txId): TxOutputWithIndex[] => {
-  /* tslint:disable:no-unused-variable */
-  const [_, preparedOutputs] = outputs.reduce(
-    ([currIndex, newOutputs], output) => {
+  const preparedOutputs: [number, TxOutputWithIndex[]] = outputs.reduce(
+    ([currIndex, newOutputs]: [number, TxOutputWithIndex[]], output: TxOutput): [number, TxOutputWithIndex[]] => {
       if (!output.decoded
           || output.decoded.type === null
           || output.decoded.type === undefined) {
@@ -533,5 +532,5 @@ export const prepareOutputs = (outputs: TxOutput[], txId): TxOutputWithIndex[] =
     [0, []],
   );
 
-  return preparedOutputs;
+  return preparedOutputs[1];
 };

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -42,6 +42,7 @@ import {
   TokenBalanceMap,
   TxInput,
   TxOutput,
+  TxOutputWithIndex,
   DbTxOutput,
   Tx,
   Wallet,
@@ -121,7 +122,7 @@ export const unlockUtxos = async (mysql: ServerlessMysql, utxos: DbTxOutput[], u
  * @param now - Current timestamp
  * @param hasHeightLock - Flag that tells if outputs are locked by height
  */
-export const markLockedOutputs = (outputs: TxOutput[], now: number, hasHeightLock = false): void => {
+export const markLockedOutputs = (outputs: TxOutputWithIndex[], now: number, hasHeightLock = false): void => {
   for (const output of outputs) {
     output.locked = false;
     if (hasHeightLock || output.decoded.timelock > now) {
@@ -506,3 +507,31 @@ export const walletIdProxyHandler = (handler: WalletProxyHandler): APIGatewayPro
     return handler(walletId, event, context);
   }
 );
+
+export const prepareOutputs = (outputs: TxOutput[], txId): TxOutputWithIndex[] => {
+  /* tslint:disable:no-unused-variable */
+  const [_, preparedOutputs] = outputs.reduce(
+    ([currIndex, newOutputs], output) => {
+      if (!output.decoded
+          || output.decoded.type === null
+          || output.decoded.type === undefined) {
+        console.warn(`Ignoring tx output with index ${currIndex} from tx ${txId} as script couldn't be decoded.`);
+        return [currIndex + 1, newOutputs];
+      }
+
+      return [
+        currIndex + 1,
+        [
+          ...newOutputs,
+          {
+            ...output,
+            index: currIndex,
+          },
+        ],
+      ];
+    },
+    [0, []],
+  );
+
+  return preparedOutputs;
+};

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -22,7 +22,7 @@ import {
   TokenBalanceMap,
   TokenInfo,
   TxInput,
-  TxOutput,
+  TxOutputWithIndex,
   TxProposal,
   TxProposalStatus,
   TxTokenBalance,
@@ -523,14 +523,14 @@ export const updateWalletTablesWithTx = async (
 export const addUtxos = async (
   mysql: ServerlessMysql,
   txId: string,
-  outputs: TxOutput[],
+  outputs: TxOutputWithIndex[],
   heightlock: number = null,
 ): Promise<void> => {
   // outputs might be empty if we're destroying authorities
   if (outputs.length === 0) return;
 
   const entries = outputs.map(
-    (output, index) => {
+    (output) => {
       let authorities = 0;
       let value = output.value;
 
@@ -541,7 +541,7 @@ export const addUtxos = async (
 
       return [
         txId,
-        index,
+        output.index,
         output.token,
         value,
         authorities,

--- a/src/types.ts
+++ b/src/types.ts
@@ -506,6 +506,10 @@ export interface TxOutput {
   locked?: boolean;
 }
 
+export interface TxOutputWithIndex extends TxOutput {
+  index: number;
+}
+
 export interface TxInput {
   // eslint-disable-next-line camelcase
   tx_id: string;

--- a/tests/commons.test.ts
+++ b/tests/commons.test.ts
@@ -72,9 +72,9 @@ test('markLockedOutputs and getAddressBalanceMap', () => {
     createInput(3, 'address2', 'inputTx', 2, 'token1'),
   ];
   tx.outputs = [
-    createOutput(5, 'address1', 'token1'),
-    createOutput(2, 'address1', 'token3'),
-    createOutput(11, 'address2', 'token1'),
+    createOutput(0, 5, 'address1', 'token1'),
+    createOutput(1, 2, 'address1', 'token3'),
+    createOutput(2, 11, 'address2', 'token1'),
   ];
   const map1 = new TokenBalanceMap();
   map1.set('token1', new Balance(-10, 0));
@@ -114,7 +114,7 @@ test('markLockedOutputs and getAddressBalanceMap', () => {
   // a block will have its rewards locked, even with no timelock
   tx.inputs = [];
   tx.outputs = [
-    createOutput(100, 'address1', 'token1'),
+    createOutput(0, 100, 'address1', 'token1'),
   ];
   markLockedOutputs(tx.outputs, now, true);
   for (const output of tx.outputs) {
@@ -134,8 +134,8 @@ test('markLockedOutputs and getAddressBalanceMap', () => {
     createInput(0b10, 'address1', 'inputTx', 1, 'token2', null, 129),
   ];
   tx.outputs = [
-    createOutput(0b01, 'address1', 'token1', null, false, 129),
-    createOutput(0b10, 'address1', 'token2', 1000, true, 129),
+    createOutput(0, 0b01, 'address1', 'token1', null, false, 129),
+    createOutput(1, 0b10, 'address1', 'token2', 1000, true, 129),
   ];
   const map4 = new TokenBalanceMap();
   map4.set('token1', new Balance(0, 0, null));

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -499,10 +499,18 @@ test('addUtxos, getUtxos, unlockUtxos, updateTxOutputSpentBy, unspendUtxos, getT
   await addUtxos(mysql, txId, []);
 
   // add to utxo table
-  const outputs = utxos.map((utxo) => createOutput(utxo.value, utxo.address, utxo.tokenId, utxo.timelock || null, utxo.locked, utxo.tokenData || 0));
+  const outputs = utxos.map((utxo, index) => createOutput(
+    index,
+    utxo.value,
+    utxo.address,
+    utxo.tokenId,
+    utxo.timelock || null,
+    utxo.locked,
+    utxo.tokenData || 0,
+  ));
   await addUtxos(mysql, txId, outputs);
 
-  for (const [index, output] of outputs.entries()) {
+  for (const [_, output] of outputs.entries()) {
     let { value } = output;
     const { token, decoded } = output;
     let authorities = 0;
@@ -511,7 +519,7 @@ test('addUtxos, getUtxos, unlockUtxos, updateTxOutputSpentBy, unspendUtxos, getT
       value = 0;
     }
     await expect(
-      checkUtxoTable(mysql, utxos.length, txId, index, token, decoded.address, value, authorities, decoded.timelock, null, output.locked),
+      checkUtxoTable(mysql, utxos.length, txId, output.index, token, decoded.address, value, authorities, decoded.timelock, null, output.locked),
     ).resolves.toBe(true);
   }
 
@@ -593,7 +601,7 @@ test('getLockedUtxoFromInputs', async () => {
   ];
 
   // add to utxo table
-  const outputs = utxos.map((utxo) => createOutput(utxo.value, utxo.address, utxo.token, utxo.timelock || null, utxo.locked));
+  const outputs = utxos.map((utxo, index) => createOutput(index, utxo.value, utxo.address, utxo.token, utxo.timelock || null, utxo.locked));
   await addUtxos(mysql, txId, outputs);
   for (const [index, output] of outputs.entries()) {
     const { token, decoded, value } = output;
@@ -883,9 +891,9 @@ test('getUtxosLockedAtHeight', async () => {
   ];
 
   // add to utxo table
-  const outputs = utxos.map((utxo) => createOutput(utxo.value, utxo.address, utxo.token, utxo.timelock, utxo.locked));
+  const outputs = utxos.map((utxo, index) => createOutput(index, utxo.value, utxo.address, utxo.token, utxo.timelock, utxo.locked));
   await addUtxos(mysql, txId, outputs, null);
-  const outputs2 = utxos2.map((utxo) => createOutput(utxo.value, utxo.address, utxo.token, utxo.timelock, utxo.locked));
+  const outputs2 = utxos2.map((utxo, index) => createOutput(index, utxo.value, utxo.address, utxo.token, utxo.timelock, utxo.locked));
   await addUtxos(mysql, txId2, outputs2, 10);
 
   // fetch on timestamp=99 and heightlock=10. Should return:
@@ -1191,7 +1199,7 @@ test('markUtxosWithProposalId and getTxProposalInputs', async () => {
   }];
 
   // add to utxo table
-  const outputs = utxos.map((utxo) => createOutput(utxo.value, utxo.address, utxo.tokenId, utxo.timelock, utxo.locked));
+  const outputs = utxos.map((utxo, index) => createOutput(index, utxo.value, utxo.address, utxo.tokenId, utxo.timelock, utxo.locked));
   await addUtxos(mysql, txId, outputs);
 
   // we'll only mark utxos with indexes 0 and 2
@@ -1437,7 +1445,15 @@ test('rebuildAddressBalancesFromUtxos', async () => {
     { value: 0b11, address: addr1, token: 'token1', locked: false, tokenData: 129 },
   ];
 
-  const outputs = utxos.map((utxo) => createOutput(utxo.value, utxo.address, utxo.token, utxo.timelock || null, utxo.locked, utxo.tokenData || 0));
+  const outputs = utxos.map((utxo, index) => createOutput(
+    index,
+    utxo.value,
+    utxo.address,
+    utxo.token,
+    utxo.timelock || null,
+    utxo.locked,
+    utxo.tokenData || 0,
+  ));
 
   await addUtxos(mysql, txId, outputs);
   await rebuildAddressBalancesFromUtxos(mysql, ['address1', 'address2']);

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -44,7 +44,7 @@ const txId1 = 'txId1';
 block.tx_id = txId1;
 block.timestamp = now;
 block.height = 1;
-block.outputs = [createOutput(blockReward, 'HNwiHGHKBNbeJPo9ToWvFWeNQkJrpicYci')];
+block.outputs = [createOutput(0, blockReward, 'HNwiHGHKBNbeJPo9ToWvFWeNQkJrpicYci')];
 
 // receive another block. Reward from first block should now be unlocked
 const blockEvent2 = JSON.parse(JSON.stringify(eventTemplate));
@@ -53,7 +53,7 @@ const txId2 = 'txId2';
 block2.tx_id = txId2;
 block2.timestamp = block.timestamp + 30;
 block2.height = block.height + 1;
-block2.outputs = [createOutput(blockReward, 'HNwiHGHKBNbeJPo9ToWvFWeNQkJrpicYci')];
+block2.outputs = [createOutput(0, blockReward, 'HNwiHGHKBNbeJPo9ToWvFWeNQkJrpicYci')];
 
 // tx sends first block rewards to 2 addresses on the same wallet
 const txEvent = JSON.parse(JSON.stringify(eventTemplate));
@@ -64,8 +64,8 @@ tx.tx_id = txId3;
 tx.timestamp += 20;
 tx.inputs = [createInput(blockReward, 'HNwiHGHKBNbeJPo9ToWvFWeNQkJrpicYci', txId1, 0)];
 tx.outputs = [
-  createOutput(blockReward - 5000, 'HUxu47MwBYNHG8jWebvzQ2jymV6PcEfWB4'),
-  createOutput(5000, 'H7ehmrWPqEQWJUqSKAxtQJX99gTPzW3aag'),
+  createOutput(0, blockReward - 5000, 'HUxu47MwBYNHG8jWebvzQ2jymV6PcEfWB4'),
+  createOutput(1, 5000, 'H7ehmrWPqEQWJUqSKAxtQJX99gTPzW3aag'),
 ];
 
 // tx sends one of last tx's outputs to 2 addresses, one of which is not from this wallet. Also, output sent to this wallet is locked
@@ -78,8 +78,8 @@ tx2.tx_id = txId4;
 tx2.timestamp += 20;
 tx2.inputs = [createInput(5000, 'H7ehmrWPqEQWJUqSKAxtQJX99gTPzW3aag', txId2, 1)];
 tx2.outputs = [
-  createOutput(1000, 'HGTfVrFshpTD6Dapuq6z9hrRaiwDYxwLcr', '00', timelock),   // belongs to this wallet
-  createOutput(4000, 'HCuWC2qgNP47BtWtsTM48PokKitVdR6pch'),   // other wallet
+  createOutput(0, 1000, 'HGTfVrFshpTD6Dapuq6z9hrRaiwDYxwLcr', '00', timelock),   // belongs to this wallet
+  createOutput(1, 4000, 'HCuWC2qgNP47BtWtsTM48PokKitVdR6pch'),   // other wallet
 ];
 
 beforeEach(async () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -4,7 +4,7 @@ import { ServerlessMysql } from 'serverless-mysql';
 import {
   DbSelectResult,
   TxInput,
-  TxOutput,
+  TxOutputWithIndex,
   FullNodeVersionData,
 } from '@src/types';
 
@@ -66,11 +66,12 @@ export const cleanDatabase = async (mysql: ServerlessMysql): Promise<void> => {
   }
 };
 
-export const createOutput = (value: number, address: string, token = '00', timelock: number = null, locked = false, tokenData = 0): TxOutput => (
+export const createOutput = (index: number, value: number, address: string, token = '00', timelock: number = null, locked = false, tokenData = 0): TxOutputWithIndex => (
   {
     value,
     token,
     locked,
+    index,
     decoded: {
       type: 'P2PKH',
       address,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "lib": ["es2017"],
     "removeComments": true,
     "moduleResolution": "node",
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "sourceMap": true,
     "target": "es2017",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "removeComments": true,
     "moduleResolution": "node",
     "noUnusedLocals": false,
-    "noUnusedParameters": true,
+    "noUnusedParameters": false,
     "sourceMap": true,
     "target": "es2017",
     "outDir": "./dist",


### PR DESCRIPTION
# Acceptance criteria

The wallet-service should ignore outputs with invalid data, like the ones from NFT transactions and store the rest of the outputs with the correct index.

## Motivation

Before this PR, the daemon was sending the list of outputs without the custom data output and the wallet-service was using the index from the iterator (`map(outputs, (output, index) => ...`) to store the output index.

We could set the output index on the daemon, but I think a better solution is to leave this to the wallet service, so we can be independent of the service that is sending transactions to it.