### PR TITLE
chore: added index to txproposal on tx_output table

### DIFF
--- a/db/migrations/20210902175955-tx_output_txproposal_index.js
+++ b/db/migrations/20210902175955-tx_output_txproposal_index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addIndex(
+      'tx_output',
+      ['tx_proposal'],
+      {
+        name: 'tx_output_txproposal_idx',
+        fields: 'tx_proposal',
+      }
+    )
+  },
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.removeIndex('tx_output', 'tx_output_txproposal_idx');
+  },
+};

--- a/db/models/txoutput.js
+++ b/db/models/txoutput.js
@@ -94,6 +94,9 @@ module.exports = (sequelize, DataTypes) => {
     }, {
       name: 'tx_output_timelock_idx',
       fields: 'timelock',
+    }, {
+      name: 'tx_output_txproposal_idx',
+      fields: 'tx_proposal',
     }],
   });
   return TxOutput;


### PR DESCRIPTION
# Acceptance criteria

Queries using the `txproposal` column on the `tx_output` should use the `tx_output_txproposal_idx` index:

```+----+-------------+-----------+------------+------+--------------------------+--------------------------+---------+-------+------+----------+----------------+
| id | select_type | table     | partitions | type | possible_keys            | key                      | key_len | ref   | rows | filtered | Extra          |
+----+-------------+-----------+------------+------+--------------------------+--------------------------+---------+-------+------+----------+----------------+
|  1 | SIMPLE      | tx_output | NULL       | ref  | tx_output_txproposal_idx | tx_output_txproposal_idx | 147     | const |    1 |   100.00 | Using filesort |
+----+-------------+-----------+------------+------+--------------------------+--------------------------+---------+-------+------+----------+----------------+
```

## Motivation

This showed up on the `slow_log` alert on our slack channel while @pedroferreira1 was testing the wallet-service `createTxProposal` and `sendTxProposal` APIs