### PR TITLE
fix: websocket routes need api gateway responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ This action is idempotent, the lambda just responds with a `PONG` message.
 
 #### WebSocket Action: Join Wallet
 - Trigger: Client initiated
-- body: `{"action":"joinWallet", "wallet":"my-wallet-id"}`
+- body: `{"action":"join", "id":"my-wallet-id"}`
 
 This action will subscribe the client to any updates of the wallet identified by the id on the body.
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -74,8 +74,7 @@ provider:
     MAX_ADDRESS_GAP: ${env:MAX_ADDRESS_GAP}
     NETWORK: ${env:NETWORK}
     NEW_TX_SQS: { Ref: WalletServiceNewTxQueue }
-    REDIS_HOST: ${env:REDIS_HOST}
-    REDIS_PORT: ${env:REDIS_PORT}
+    REDIS_URL: ${env:REDIS_URL}
     REDIS_PASSWORD: ${env:REDIS_PASSWORD}
     SERVICE_NAME: ${self:service}
     STAGE: ${opt:stage, 'dev'}

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -7,8 +7,7 @@ import redis from 'redis';
 import { promisify } from 'util';
 
 const redisConfig: RedisConfig = {
-  host: process.env.REDIS_HOST,
-  port: parseInt(process.env.REDIS_PORT, 10),
+  url: process.env.REDIS_URL,
   password: process.env.REDIS_PASSWORD,
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -563,8 +563,7 @@ export type WsConnectionInfo = {
 }
 
 export type RedisConfig = {
-  host: string;
-  port?: number;
+  url: string;
   password?: string;
 };
 

--- a/src/ws/connection.ts
+++ b/src/ws/connection.ts
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import {
+  APIGatewayProxyEvent,
+  APIGatewayProxyResult,
+} from 'aws-lambda';
 import {
   connectionInfoFromEvent,
   sendMessageToClient,
@@ -22,7 +25,7 @@ const mysql = getDbConnection();
 
 export const connect = async (
   event: APIGatewayProxyEvent,
-): Promise<void> => {
+): Promise<APIGatewayProxyResult> => {
   const redisClient = getRedisClient();
   const routeKey = event.requestContext.routeKey;
   // info needed to send response to client
@@ -42,4 +45,8 @@ export const connect = async (
 
   await closeRedisClient(redisClient);
   await closeDbConnection(mysql);
+
+  return {
+    statusCode: 200,
+  };
 };

--- a/src/ws/connection.ts
+++ b/src/ws/connection.ts
@@ -12,6 +12,7 @@ import {
 import {
   connectionInfoFromEvent,
   sendMessageToClient,
+  DEFAULT_API_GATEWAY_RESPONSE,
 } from '@src/ws/utils';
 import {
   getRedisClient,
@@ -46,7 +47,5 @@ export const connect = async (
   await closeRedisClient(redisClient);
   await closeDbConnection(mysql);
 
-  return {
-    statusCode: 200,
-  };
+  return DEFAULT_API_GATEWAY_RESPONSE;
 };

--- a/src/ws/join.ts
+++ b/src/ws/join.ts
@@ -14,6 +14,7 @@ import { closeDbConnection, getDbConnection } from '@src/utils';
 import {
   connectionInfoFromEvent,
   sendMessageToClient,
+  DEFAULT_API_GATEWAY_RESPONSE,
 } from '@src/ws/utils';
 import {
   getRedisClient,
@@ -50,9 +51,8 @@ export const handler = async (
   await closeDbConnection(mysql);
   await closeRedisClient(redisClient);
 
-  return {
-    statusCode: 200,
-  };
+  // Since this is served by ApiGateway, we need to return a APIGatewayProxyResult
+  return DEFAULT_API_GATEWAY_RESPONSE;
 };
 
 const joinWallet = async (
@@ -73,7 +73,7 @@ const joinWallet = async (
       success: false,
       message: 'Invalid parameters',
     });
-    return;
+    return DEFAULT_API_GATEWAY_RESPONSE;
   }
 
   // TODO: Verify ownership of the wallet upon subscription.
@@ -88,7 +88,7 @@ const joinWallet = async (
       success: false,
       message: 'Invalid parameters',
     });
-    return;
+    return DEFAULT_API_GATEWAY_RESPONSE;
   }
 
   await wsJoinWallet(_client, connInfo, walletId);
@@ -98,7 +98,5 @@ const joinWallet = async (
     id: walletId,
   });
 
-  return {
-    statusCode: 200,
-  };
+  return DEFAULT_API_GATEWAY_RESPONSE;
 };

--- a/src/ws/join.ts
+++ b/src/ws/join.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { ServerlessMysql } from 'serverless-mysql';
 import { RedisClient } from 'redis';
 import Joi from 'joi';
@@ -42,13 +42,17 @@ const parseBody = (body: string) => {
 
 export const handler = async (
   event: APIGatewayProxyEvent,
-): Promise<void> => {
+): Promise<APIGatewayProxyResult> => {
   const redisClient = getRedisClient();
   const connInfo = connectionInfoFromEvent(event);
 
   await joinWallet(event, connInfo, mysql, redisClient);
   await closeDbConnection(mysql);
   await closeRedisClient(redisClient);
+
+  return {
+    statusCode: 200,
+  };
 };
 
 const joinWallet = async (
@@ -56,7 +60,7 @@ const joinWallet = async (
   connInfo: WsConnectionInfo,
   _mysql: ServerlessMysql,
   _client: RedisClient,
-): Promise<void> => {
+): Promise<APIGatewayProxyResult> => {
   // parse body and extract wallet
   const body = parseBody(event.body);
   const { value, error } = joinSchema.validate(body, {
@@ -93,4 +97,8 @@ const joinWallet = async (
     message: 'Listening',
     id: walletId,
   });
+
+  return {
+    statusCode: 200,
+  };
 };

--- a/src/ws/utils.ts
+++ b/src/ws/utils.ts
@@ -1,4 +1,4 @@
-import { APIGatewayProxyEvent } from 'aws-lambda';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { RedisClient } from 'redis';
 
 import AWS from 'aws-sdk';
@@ -76,4 +76,9 @@ export const disconnectClient = async (
       throw err;
     },
   );
+};
+
+export const DEFAULT_API_GATEWAY_RESPONSE: APIGatewayProxyResult = {
+  statusCode: 200,
+  body: '',
 };


### PR DESCRIPTION
# Acceptance criteria

The user must be able to connect to websocket without receiving a 502

## Motivation

We are not answering requests to websocket routes with proper API Gateway responses. It works on serverless-offline as it is not using API Gateway to answer requests, but fails after it is deployed. 