### PR TITLE
chore: tuned sqs event sourcing batch size to have faster ws realtime…

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -224,8 +224,8 @@ functions:
             Fn::GetAtt:
               - WalletServiceNewTxQueue
               - Arn
-          batchSize: 1
-          maximumBatchingWindow: 0
+          batchSize: 10
+          maximumBatchingWindow: 3
   wsTxNotifyUpdate:
     handler: src/ws/txNotify.onUpdateTx
     timeout: 1

--- a/serverless.yml
+++ b/serverless.yml
@@ -224,8 +224,8 @@ functions:
             Fn::GetAtt:
               - WalletServiceNewTxQueue
               - Arn
-          batchSize: 10
-          maximumBatchingWindow: 60
+          batchSize: 1
+          maximumBatchingWindow: 0
   wsTxNotifyUpdate:
     handler: src/ws/txNotify.onUpdateTx
     timeout: 1


### PR DESCRIPTION
# Acceptance criteria

Transactions should be processed by `wsTxNotifyNew` as they are received on the SQS queue in real time

## Motivation

Currently, with `batchSize: 10`, the `newTx` event is apparently only processed when there are at least 10 new transactions (to fill the batch size), so they are taking around 2 minutes to appear on the websocket feed

To solve this, I've set the [MaximumBatchingWindowInSeconds](https://docs.aws.amazon.com/pt_br/lambda/latest/dg/API_EventSourceMappingConfiguration.html) to 3s to the most it will take (before filling 10 transactions in a batch) is 3s