### PR TITLE
refactor: added type to websocket responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ so the lambda can filter and send the message to the right clients.
 #### WebSocket Action: PING
 - Trigger: Client initiated
 - body: `{"action":"ping"}`
-- response: `{"message":"PONG"}`
+- response: `{"message":"pong"}`
 
 This action is idempotent, the lambda just responds with a `PONG` message.
 
@@ -177,13 +177,13 @@ This action will subscribe the client to any updates of the wallet identified by
 - Trigger: SQS Event
 - When: A new tx is processed by the wallet-service
 - To: All wallets affected by the tx
-- body: The tx in JSON format
+- body: `{"type": "new-tx", "data": "..."}`
 
 #### WebSocket Action: Update TX
 - Trigger: SQS Event
 - When: An update is made to a tx that was already processed
 - To: All wallets affected by the tx
-- body: The update information and tx id
+- body: `{"type": "update-tx", "data": "..."}`
 
 ### Troubleshooting
 

--- a/src/ws/connection.ts
+++ b/src/ws/connection.ts
@@ -41,7 +41,7 @@ export const connect = async (
   }
 
   if (routeKey === 'ping') {
-    await sendMessageToClient(redisClient, connInfo, { message: 'PONG' });
+    await sendMessageToClient(redisClient, connInfo, { type: 'pong' });
   }
 
   await closeRedisClient(redisClient);

--- a/src/ws/join.ts
+++ b/src/ws/join.ts
@@ -70,7 +70,7 @@ const joinWallet = async (
 
   if (error) {
     await sendMessageToClient(_client, connInfo, {
-      success: false,
+      type: 'error',
       message: 'Invalid parameters',
     });
     return DEFAULT_API_GATEWAY_RESPONSE;
@@ -85,7 +85,7 @@ const joinWallet = async (
   if (wallet === null) {
     // wallet does not exist, but should we return an error?
     await sendMessageToClient(_client, connInfo, {
-      success: false,
+      type: 'error',
       message: 'Invalid parameters',
     });
     return DEFAULT_API_GATEWAY_RESPONSE;
@@ -93,7 +93,7 @@ const joinWallet = async (
 
   await wsJoinWallet(_client, connInfo, walletId);
   await sendMessageToClient(_client, connInfo, {
-    success: true,
+    type: 'join-success',
     message: 'Listening',
     id: walletId,
   });

--- a/src/ws/txNotify.ts
+++ b/src/ws/txNotify.ts
@@ -63,13 +63,18 @@ export const onNewTx: SQSHandler = async (event) => {
     const wallets = value.wallets;
     const tx = value.tx;
 
+    const payload = {
+      type: 'new-tx',
+      data: tx,
+    };
+
     // This will create a promise that for each walletId on wallets it will search for all open connections
     // and for each connection send the payload (the JSON representation of the tx) using sendMessageToClient
     promises.push(
       Promise.all(wallets.map((walletId) => (
         wsGetWalletConnections(redisClient, walletId).then((connections) => (
           Promise.all(connections.map((connInfo) => (
-            sendMessageToClient(redisClient, connInfo, tx)
+            sendMessageToClient(redisClient, connInfo, payload)
           )))
         ))
       ))),
@@ -100,13 +105,17 @@ export const onUpdateTx: SQSHandler = async (event) => {
 
     const wallets = value.wallets;
     const updateBody = value.update;
+    const payload = {
+      type: 'update-tx',
+      data: updateBody,
+    };
 
     // Same logic as onNewTx, but sending `updateBody` as payload
     promises.push(
       Promise.all(wallets.map((walletId) => (
         wsGetWalletConnections(redisClient, walletId).then((connections) => (
           Promise.all(connections.map((connInfo) => (
-            sendMessageToClient(redisClient, connInfo, updateBody)
+            sendMessageToClient(redisClient, connInfo, payload)
           )))
         ))
       ))),


### PR DESCRIPTION
# Acceptance criteria

The wallet service websocket api should return a key `type` on messages