### PR TITLE
chore: added index to tx_id on address_tx_history

### DIFF
--- a/db/migrations/20211017211022-address_tx_history_tx_id_index.js
+++ b/db/migrations/20211017211022-address_tx_history_tx_id_index.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.addIndex(
+      'address_tx_history',
+      ['tx_id'],
+      {
+        name: 'address_tx_history_txid_idx',
+        fields: 'tx_id',
+      }
+    )
+  },
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.removeIndex('address_tx_history', 'address_tx_history_txid_idx');
+  },
+};

--- a/db/models/addresstxhistory.js
+++ b/db/models/addresstxhistory.js
@@ -47,6 +47,10 @@ module.exports = (sequelize, DataTypes) => {
     modelName: 'AddressTxHistory',
     tableName: 'address_tx_history',
     timestamps: false,
+    indexes: [{
+      name: 'address_tx_history_txid_idx',
+      fields: ['tx_id'],
+    }],
   });
   return AddressTxHistory;
 };


### PR DESCRIPTION
# Acceptance criteria

Queries by `tx_id` on the `address_tx_history` table should use the index on `tx_id`

## Motivation

Queries would get increasingly slower depending on the number of transactions on the database as the `address_tx_history` had no index on `tx_id`. Here is an example EXPLAIN on a query on the `address_tx_history` table:

```+----+-------------+--------------------+------------+-------+---------------+---------+---------+------+---------+----------+-------------+
| id | select_type | table              | partitions | type  | possible_keys | key     | key_len | ref  | rows    | filtered | Extra       |
+----+-------------+--------------------+------------+-------+---------------+---------+---------+------+---------+----------+-------------+
|  1 | UPDATE      | address_tx_history | NULL       | index | NULL          | PRIMARY | 654     | NULL | 2380199 |   100.00 | Using where |
+----+-------------+--------------------+------------+-------+---------------+---------+---------+------+---------+----------+-------------+``` 