### PR TITLE
chore: forcing primary index for faster queries on huge SELECT IN

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -700,7 +700,7 @@ export const getUtxos = async (
   const entries = utxosInfo.map((utxo) => [utxo.txId, utxo.index]);
   const results: DbSelectResult = await mysql.query(
     `SELECT *
-       FROM \`tx_output\`
+       FROM \`tx_output\` USE INDEX (PRIMARY)
       WHERE (\`tx_id\`, \`index\`)
          IN (?)
         AND \`spent_by\` IS NULL


### PR DESCRIPTION
### Motivation

`getUtxos` database query was taking too long when the number of utxos to search was too large 

This is an example query:
```sql
SELECT *
         FROM `tx_output`
        WHERE (`tx_id` ,`index`)
           IN (('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 0),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 1),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 2),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 3),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 4),
           (...)
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 244),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 245),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 246),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 247),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 248),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 249))  
        AND `locked` = TRUE
          AND `spent_by` IS NULL
          AND `voided` = FALSE;
```

This is the profiling for this query:

```
+----------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Query_ID | Duration    | Query                                                                                                                                                                                                                                                                                                        |
+----------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|        1 | 24.76975725 | SELECT *
         FROM `tx_output`
        WHERE (`tx_id` ,`index`)
           IN (('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 0),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 1),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3 |
+----------+-------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

This is the same query profile after the change:

```
+----------+------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Query_ID | Duration   | Query                                                                                                                                                                                                                                                                                                        |
+----------+------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|        1 | 0.05202800 | SELECT *
         FROM `tx_output` USE INDEX (PRIMARY)
        WHERE (`tx_id` ,`index`)
           IN (('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 0),
           ('000000003e682adc3c947821cf5f52ab5e53663188c2eb3283d6d86d36917d09', 1),
           ('000000003e682adc3c947821cf5 |
+----------+------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Apparently this is the same behaviour from this issue: https://github.com/HathorNetwork/hathor-wallet-service/pull/140

### Acceptance Criteria
- Queries with a large number of `utxos` to search for should take less than a second to run
- Other queries should not be affected by this change


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
