### PR TITLE
fix: added methods to unlock old timelocked utxos

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -15,7 +15,7 @@ import {
   getLatestHeight,
   getWalletBalances as dbGetWalletBalances,
   getWalletUnlockedUtxos,
-  getTimelockedUtxos,
+  getExpiredTimelocksUtxos,
   unlockUtxos as dbUnlockUtxos,
   updateAddressLockedBalance,
   updateWalletLockedBalance,
@@ -118,7 +118,7 @@ export const unlockUtxos = async (mysql: ServerlessMysql, utxos: DbTxOutput[], u
  * @param now - Current timestamp
  */
 export const unlockTimelockedUtxos = async (mysql: ServerlessMysql, now: number): Promise<void> => {
-  const utxos: DbTxOutput[] = await getTimelockedUtxos(mysql, now);
+  const utxos: DbTxOutput[] = await getExpiredTimelocksUtxos(mysql, now);
 
   await unlockUtxos(mysql, utxos, true);
 };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2334,18 +2334,17 @@ export const getTotalSupply = async (
 };
 
 /**
- * Unlock timelocked utxos returning the list of utxos that were updated
+ * Get timelocked utxos from the database
  *
  * @param mysql - Database connection
  * @param now - Current timestamp
 
- * @returns A list of unlocked utxos
+ * @returns A list of timelocked utxos
  */
-export const unlockTimelockedUtxos = async (
+export const getTimelockedUtxos = async (
   mysql: ServerlessMysql,
   now: number,
 ): Promise<DbTxOutput[]> => {
-  // this might be inefficient but MySQL does not support "RETURNING" the updated values
   const results: DbSelectResult = await mysql.query(`
     SELECT *
       FROM tx_output
@@ -2355,8 +2354,6 @@ export const unlockTimelockedUtxos = async (
   `, [now]);
 
   const lockedUtxos: DbTxOutput[] = results.map(mapDbResultToDbTxOutput);
-
-  await unlockUtxos(mysql, lockedUtxos);
 
   return lockedUtxos;
 };

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2334,14 +2334,14 @@ export const getTotalSupply = async (
 };
 
 /**
- * Get timelocked utxos from the database
+ * Get from database utxos that must be unlocked because their timelocks expired
  *
  * @param mysql - Database connection
  * @param now - Current timestamp
 
  * @returns A list of timelocked utxos
  */
-export const getTimelockedUtxos = async (
+export const getExpiredTimelocksUtxos = async (
   mysql: ServerlessMysql,
   now: number,
 ): Promise<DbTxOutput[]> => {

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -248,7 +248,9 @@ const _unsafeAddNewTx = async (tx: Transaction, now: number, blockRewardLock: nu
     //
     // we've decided to do this here considering that it is acceptable to have
     // a delay between the actual timelock expiration time and the next block
-    // (that will unlock it).
+    // (that will unlock it). This delay is only perceived on the wallet as the
+    // sync mechanism will unlock the timelocked utxos as soon as they are seen
+    // on a received transaction.
     await unlockTimelockedUtxos(mysql, now);
   }
 

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -14,6 +14,7 @@ import {
   getWalletBalanceMap,
   markLockedOutputs,
   unlockUtxos,
+  unlockTimelockedUtxos,
   searchForLatestValidBlock,
   handleReorg,
   handleVoided,
@@ -241,6 +242,14 @@ const _unsafeAddNewTx = async (tx: Transaction, now: number, blockRewardLock: nu
 
     // add miner to the miners table
     await addMiner(mysql, blockRewardOutput.decoded.address, tx.tx_id);
+
+    // here we check if we have any utxos on our database that is locked but
+    // has its timelock < now
+    //
+    // we've decided to do this here considering that it is acceptable to have
+    // a delay between the actual timelock expiration time and the next block
+    // (that will unlock it).
+    await unlockTimelockedUtxos(mysql, now);
   }
 
   if (tx.version === hathorLib.constants.CREATE_TOKEN_TX_VERSION) {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -56,7 +56,7 @@ import {
   addMiner,
   getMinersList,
   getTotalSupply,
-  unlockTimelockedUtxos,
+  getTimelockedUtxos,
 } from '@src/db';
 import {
   beginTransaction,
@@ -1758,7 +1758,7 @@ test('getTotalSupply', async () => {
   expect(await getTotalSupply(mysql, 'token1')).toStrictEqual(35);
 });
 
-test('unlockTimelockedUtxos', async () => {
+test('getTimelockedUtxos', async () => {
   expect.hasAssertions();
 
   const txId = 'txId';
@@ -1787,17 +1787,17 @@ test('unlockTimelockedUtxos', async () => {
 
   await addUtxos(mysql, txId, outputs);
 
-  const unlockedUtxos0: DbTxOutput[] = await unlockTimelockedUtxos(mysql, 100);
-  const unlockedUtxos1: DbTxOutput[] = await unlockTimelockedUtxos(mysql, 101);
-  const unlockedUtxos2: DbTxOutput[] = await unlockTimelockedUtxos(mysql, 201);
-  const unlockedUtxos3: DbTxOutput[] = await unlockTimelockedUtxos(mysql, 301);
+  const unlockedUtxos0: DbTxOutput[] = await getTimelockedUtxos(mysql, 100);
+  const unlockedUtxos1: DbTxOutput[] = await getTimelockedUtxos(mysql, 101);
+  const unlockedUtxos2: DbTxOutput[] = await getTimelockedUtxos(mysql, 201);
+  const unlockedUtxos3: DbTxOutput[] = await getTimelockedUtxos(mysql, 301);
 
   expect(unlockedUtxos0).toHaveLength(0);
   expect(unlockedUtxos1).toHaveLength(1);
   expect(unlockedUtxos1[0].value).toStrictEqual(outputs[2].value);
-  expect(unlockedUtxos2).toHaveLength(1);
-  expect(unlockedUtxos2[0].value).toStrictEqual(outputs[3].value);
-  expect(unlockedUtxos3).toHaveLength(1);
+  expect(unlockedUtxos2).toHaveLength(2);
+  expect(unlockedUtxos2[1].value).toStrictEqual(outputs[3].value);
+  expect(unlockedUtxos3).toHaveLength(3);
   // last one is an authority utxo
-  expect(unlockedUtxos3[0].authorities).toStrictEqual(outputs[4].value);
+  expect(unlockedUtxos3[2].authorities).toStrictEqual(outputs[4].value);
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -56,7 +56,7 @@ import {
   addMiner,
   getMinersList,
   getTotalSupply,
-  getTimelockedUtxos,
+  getExpiredTimelocksUtxos,
 } from '@src/db';
 import {
   beginTransaction,
@@ -1758,7 +1758,7 @@ test('getTotalSupply', async () => {
   expect(await getTotalSupply(mysql, 'token1')).toStrictEqual(35);
 });
 
-test('getTimelockedUtxos', async () => {
+test('getExpiredTimelocksUtxos', async () => {
   expect.hasAssertions();
 
   const txId = 'txId';
@@ -1787,10 +1787,10 @@ test('getTimelockedUtxos', async () => {
 
   await addUtxos(mysql, txId, outputs);
 
-  const unlockedUtxos0: DbTxOutput[] = await getTimelockedUtxos(mysql, 100);
-  const unlockedUtxos1: DbTxOutput[] = await getTimelockedUtxos(mysql, 101);
-  const unlockedUtxos2: DbTxOutput[] = await getTimelockedUtxos(mysql, 201);
-  const unlockedUtxos3: DbTxOutput[] = await getTimelockedUtxos(mysql, 301);
+  const unlockedUtxos0: DbTxOutput[] = await getExpiredTimelocksUtxos(mysql, 100);
+  const unlockedUtxos1: DbTxOutput[] = await getExpiredTimelocksUtxos(mysql, 101);
+  const unlockedUtxos2: DbTxOutput[] = await getExpiredTimelocksUtxos(mysql, 201);
+  const unlockedUtxos3: DbTxOutput[] = await getExpiredTimelocksUtxos(mysql, 301);
 
   expect(unlockedUtxos0).toHaveLength(0);
   expect(unlockedUtxos1).toHaveLength(1);


### PR DESCRIPTION
### Acceptance Criteria
- Timelocked utxos should be unlocked on the first block after its timelock expiration time
- Balances should be re-calculated considering the unlocked balance from those utxos

### Motivation

The wallet service will currently only evaluate whether an timelocked utxo should be unlocked when a tx that spends this utxo is synced. This worked because transactions were not made using the wallet service, but now that transactions will be made using the `txProposalCreate` mechanism, those utxos will never be returned from the `findUtxos` lambda and so will never be unlocked.

**NOTICE**: I am running the `unlockTimelockedUtxos` method on every block transaction so the maximum delay between the actual timelock timestamp and the unlock will be the current interval between blocks.


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
