### PR TITLE
refactor: using bitcoinjs instead of bitcore-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3733,8 +3733,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -3754,6 +3752,73 @@
         "js-sha256": "^0.9.0",
         "randombytes": "^2.1.0",
         "safe-buffer": "^5.2.1"
+      }
+    },
+    "bip174": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bip174/-/bip174-2.0.1.tgz",
+      "integrity": "sha512-i3X26uKJOkDTAalYAp0Er+qGMDhrbbh2o93/xiPyAN2s25KrClSpe3VXo/7mNJoqA5qfko8rLS2l3RWZgYmjKQ=="
+    },
+    "bip32": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-3.0.1.tgz",
+      "integrity": "sha512-Uhpp9aEx3iyiO7CpbNGFxv9WcMIVdGoHG04doQ5Ln0u60uwDah7jUSc3QMV/fSZGm/Oo01/OeAmYevXV+Gz5jQ==",
+      "requires": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.12.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+          "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        }
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "bitcoinjs-lib": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-6.0.1.tgz",
+      "integrity": "sha512-x/7D4jDj/MMkmO6t3p2CSDXTqpwZ/jRsRiJDmaiXabrR9XRo7jwby8HRn7EyK1h24rKFFI7vI0ay4czl6bDOZQ==",
+      "requires": {
+        "bech32": "^2.0.0",
+        "bip174": "^2.0.1",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.1.0",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.1.2",
+        "wif": "^2.0.1"
+      }
+    },
+    "bitcoinjs-message": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-message/-/bitcoinjs-message-2.2.0.tgz",
+      "integrity": "sha512-103Wy3xg8Y9o+pdhGP4M3/mtQQuUWs6sPuOp1mYphSUoSMHjHTlkj32K4zxU8qMH0Ckv23emfkGlFWtoWZ7YFA==",
+      "requires": {
+        "bech32": "^1.1.3",
+        "bs58check": "^2.1.2",
+        "buffer-equals": "^1.0.3",
+        "create-hash": "^1.1.2",
+        "secp256k1": "^3.0.1",
+        "varuint-bitcoin": "^1.0.1"
+      },
+      "dependencies": {
+        "bech32": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+          "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+        }
       }
     },
     "bitcore-lib": {
@@ -3905,7 +3970,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "dev": true,
       "requires": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -4037,6 +4101,16 @@
         "base-x": "^3.0.2"
       }
     },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -4088,6 +4162,11 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "buffer-equals": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-equals/-/buffer-equals-1.0.4.tgz",
+      "integrity": "sha1-A1O1T9B/2VZBcGca5vZrnPENJ/U="
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -4102,8 +4181,7 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-      "dev": true
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
     },
     "buffermaker": {
       "version": "1.2.1",
@@ -4419,7 +4497,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -4949,7 +5026,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -4962,7 +5038,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -5558,6 +5633,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.2.tgz",
       "integrity": "sha512-fmrwR04lsniq/uSr8yikThDTrM7epXHBAAjH9TbeH3rEA8tdCO7mRzB9hdmdGyJCxF8KERo9CITcm3kGuoyMhg=="
+    },
+    "drbg.js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+      "requires": {
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -6403,7 +6488,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dev": true,
       "requires": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -6824,9 +6908,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -7671,7 +7753,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -7681,14 +7762,12 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -10473,7 +10552,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -10952,9 +11030,7 @@
     "nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "nanoid": {
       "version": "2.1.11",
@@ -12898,7 +12974,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -12988,6 +13063,21 @@
         "ajv": "^6.1.0",
         "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
+      }
+    },
+    "secp256k1": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
+      "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "bip66": "^1.1.5",
+        "bn.js": "^4.11.8",
+        "create-hash": "^1.2.0",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.5.2",
+        "nan": "^2.14.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "seek-bzip": {
@@ -13901,7 +13991,6 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -15185,6 +15274,14 @@
         "next-tick": "1"
       }
     },
+    "tiny-secp256k1": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-2.2.1.tgz",
+      "integrity": "sha512-/U4xfVqnVxJXN4YVsru0E6t5wVncu2uunB8+RVR40fYUxkKYUPS10f+ePQZgFBoE/Jbf9H1NBveupF2VmB58Ng==",
+      "requires": {
+        "uint8array-tools": "0.0.7"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -15599,6 +15696,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+    },
     "typescript": {
       "version": "3.9.9",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
@@ -15610,6 +15712,11 @@
       "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-0.0.1-alpha.0.tgz",
       "integrity": "sha512-1hNKM37dAWML/2ltRXupOq2uqcdRQyDFphl+341NTPXFLLLiDhErXx8VtaSLh3xP7SyHZdcCgpt9boYYVb3fQg==",
       "dev": true
+    },
+    "uint8array-tools": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.7.tgz",
+      "integrity": "sha512-vrrNZJiusLWoFWBqz5Y5KMCgP9W9hnjZHzZiZRT8oNAkq3d5Z5Oe76jAvVVSRh4U8GGR90N2X1dWtrhvx6L8UQ=="
     },
     "umzug": {
       "version": "2.3.0",
@@ -15912,6 +16019,14 @@
       "version": "10.11.0",
       "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
       "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+    },
+    "varuint-bitcoin": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.2.tgz",
+      "integrity": "sha512-4EVb+w4rx+YfVM32HQX42AbbT7/1f5zwAYhIujKXKk8NQK+JfRVl3pqT3hjNn/L+RstigmGGKVwHA/P0wgITZw==",
+      "requires": {
+        "safe-buffer": "^5.1.1"
+      }
     },
     "velocityjs": {
       "version": "2.0.3",
@@ -16381,6 +16496,14 @@
       "dev": true,
       "requires": {
         "string-width": "^4.0.0"
+      }
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
       }
     },
     "winston": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "bip32": "^3.0.1",
     "bitcoinjs-lib": "^6.0.1",
     "bitcoinjs-message": "^2.2.0",
-    "bitcore-lib": "^8.25.25",
     "joi": "^17.4.0",
     "jsonwebtoken": "^8.5.1",
     "mysql": "^2.18.1",
@@ -67,6 +66,7 @@
     "typescript": "^3.9.5",
     "typescript-eslint": "0.0.1-alpha.0",
     "webpack": "^4.29.0",
-    "webpack-node-externals": "^1.7.2"
+    "webpack-node-externals": "^1.7.2",
+    "bitcore-lib": "^8.25.25"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "aws-lambda": "^1.0.6",
     "aws-sdk": "^2.916.0",
     "axios": "^0.21.1",
+    "bip32": "^3.0.1",
+    "bitcoinjs-lib": "^6.0.1",
+    "bitcoinjs-message": "^2.2.0",
     "bitcore-lib": "^8.25.25",
     "joi": "^17.4.0",
     "jsonwebtoken": "^8.5.1",
@@ -33,6 +36,7 @@
     "sequelize": "^6.6.4",
     "serverless-mysql": "^1.5.4",
     "source-map-support": "^0.5.19",
+    "tiny-secp256k1": "^2.2.1",
     "uuid": "^8.3.0"
   },
   "devDependencies": {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -180,6 +180,7 @@ const _generatePolicy = (principalId: string, effect: string, resource: string) 
   authResponse.context = context;
 
   // XXX: to get the resulting policy on the logs, since we can't check the cached policy
+  // eslint-disable-next-line
   console.info('Generated policy:', authResponse);
   return authResponse;
 };
@@ -207,6 +208,7 @@ export const bearerAuthorizer: APIGatewayTokenAuthorizerHandler = async (event) 
     } else if (e.name === 'TokenExpiredError') {
       throw new Error('Unauthorized');
     } else {
+      // eslint-disable-next-line
       console.log('Error on bearerAuthorizer: ', e);
       throw e;
     }

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -22,6 +22,7 @@ import { Wallet } from '@src/types';
 import { getWallet } from '@src/db';
 import {
   verifySignature,
+  getAddressFromXpub,
   closeDbConnection,
   getDbConnection,
   validateAuthTimestamp,
@@ -112,8 +113,7 @@ export const tokenHandler: APIGatewayProxyHandler = async (event) => {
     };
   }
 
-  const xpubkey = bitcore.HDPublicKey(authXpubStr);
-  const address = xpubkey.publicKey.toAddress(hathorLib.network.getNetwork());
+  const address = getAddressFromXpub(authXpubStr);
   const walletId = wallet.walletId;
 
   if (!verifySignature(signature, timestamp, address, walletId)) {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -15,9 +15,7 @@ import {
 import { v4 as uuid4 } from 'uuid';
 import Joi from 'joi';
 import jwt from 'jsonwebtoken';
-import bitcore from 'bitcore-lib';
 import { ApiError } from '@src/api/errors';
-import hathorLib from '@hathor/wallet-lib';
 import { Wallet } from '@src/types';
 import { getWallet } from '@src/db';
 import {
@@ -30,8 +28,6 @@ import {
 } from '@src/utils';
 
 const EXPIRATION_TIME_IN_SECONDS = 1800;
-
-hathorLib.network.setNetwork(process.env.NETWORK);
 
 const bodySchema = Joi.object({
   ts: Joi.number().positive().required(),
@@ -219,12 +215,11 @@ export const bearerAuthorizer: APIGatewayTokenAuthorizerHandler = async (event) 
   // signature data
   const signature = data.sign;
   const timestamp = data.ts;
-  const addr = data.addr;
+  const address = data.addr;
   const walletId = data.wid;
 
   // header data
   const expirationTs = data.exp;
-  const address = new bitcore.Address(addr, hathorLib.network.getNetwork());
   const verified = verifySignature(signature, timestamp, address, walletId);
 
   if (verified && Math.floor(Date.now() / 1000) <= expirationTs) {

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -35,7 +35,6 @@ import {
 import { closeDbAndGetError } from '@src/api/utils';
 import { walletIdProxyHandler } from '@src/commons';
 import Joi from 'joi';
-import bitcore from 'bitcore-lib';
 import { network } from '@hathor/wallet-lib';
 
 const mysql = getDbConnection();
@@ -130,7 +129,6 @@ export const validateSignatures = (
   authXpubkeySignature: string,
 ): boolean => {
   // verify that the user owns the xpubkey
-  // const xpubkey = bitcore.HDPublicKey(xpubkeyStr);
   const xpubAddress = getAddressFromXpub(xpubkeyStr); // xpubkey.publicKey.toAddress(network.getNetwork());
   const xpubValid = verifySignature(xpubkeySignature, timestamp, xpubAddress.toString(), walletId.toString());
 

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -27,6 +27,7 @@ import {
   getDbConnection,
   getWalletId,
   verifySignature,
+  getAddressFromXpub,
   confirmFirstAddress,
   validateAuthTimestamp,
   AUTH_MAX_TIMESTAMP_SHIFT_IN_SECONDS,
@@ -129,14 +130,12 @@ export const validateSignatures = (
   authXpubkeySignature: string,
 ): boolean => {
   // verify that the user owns the xpubkey
-  const xpubkey = bitcore.HDPublicKey(xpubkeyStr);
-  const xpubAddress = xpubkey.publicKey.toAddress(network.getNetwork());
-  const xpubValid = verifySignature(xpubkeySignature, timestamp, xpubAddress, walletId.toString());
+  // const xpubkey = bitcore.HDPublicKey(xpubkeyStr);
+  const xpubAddress = getAddressFromXpub(xpubkeyStr); // xpubkey.publicKey.toAddress(network.getNetwork());
+  const xpubValid = verifySignature(xpubkeySignature, timestamp, xpubAddress.toString(), walletId.toString());
 
   // verify that the user owns the auth_xpubkey
-  const authXpubkey = bitcore.HDPublicKey(authXpubkeyStr);
-  const authXpubAddress = authXpubkey.publicKey.toAddress(network.getNetwork());
-
+  const authXpubAddress = getAddressFromXpub(authXpubkeyStr);
   const authXpubValid = verifySignature(authXpubkeySignature, timestamp, authXpubAddress, walletId.toString());
 
   return xpubValid && authXpubValid;

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -129,7 +129,7 @@ export const validateSignatures = (
 ): boolean => {
   // verify that the user owns the xpubkey
   const xpubAddress = getAddressFromXpub(xpubkeyStr);
-  const xpubValid = verifySignature(xpubkeySignature, timestamp, xpubAddress.toString(), walletId.toString());
+  const xpubValid = verifySignature(xpubkeySignature, timestamp, xpubAddress, walletId.toString());
 
   // verify that the user owns the auth_xpubkey
   const authXpubAddress = getAddressFromXpub(authXpubkeyStr);

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -35,7 +35,6 @@ import {
 import { closeDbAndGetError } from '@src/api/utils';
 import { walletIdProxyHandler } from '@src/commons';
 import Joi from 'joi';
-import { network } from '@hathor/wallet-lib';
 
 const mysql = getDbConnection();
 
@@ -129,7 +128,7 @@ export const validateSignatures = (
   authXpubkeySignature: string,
 ): boolean => {
   // verify that the user owns the xpubkey
-  const xpubAddress = getAddressFromXpub(xpubkeyStr); // xpubkey.publicKey.toAddress(network.getNetwork());
+  const xpubAddress = getAddressFromXpub(xpubkeyStr);
   const xpubValid = verifySignature(xpubkeySignature, timestamp, xpubAddress.toString(), walletId.toString());
 
   // verify that the user owns the auth_xpubkey
@@ -347,6 +346,7 @@ export const load: APIGatewayProxyHandler = async (event) => {
      */
     await invokeLoadWalletAsync(xpubkeyStr, maxGap);
   } catch (e) {
+    // eslint-disable-next-line
     console.error('Error on lambda wallet invoke', e);
 
     const newRetryCount = wallet.retryCount ? wallet.retryCount + 1 : 1;
@@ -413,6 +413,7 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
       xpubkey,
     };
   } catch (e) {
+    // eslint-disable-next-line
     console.error('Erroed on loadWalletAsync: ', e);
 
     const wallet = await getWallet(mysql, walletId);

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -351,10 +351,13 @@ export const searchForLatestValidBlock = async (mysql: ServerlessMysql): Promise
  * by this iteration.
  */
 export const handleVoidedTxList = async (mysql: ServerlessMysql, txs: Tx[]): Promise<[Tx[], DbTxOutput[]]> => {
+  // eslint-disable-next-line
   console.log(`Setting ${txs.length} transactions as voided.`);
   await markTxsAsVoided(mysql, txs);
+  // eslint-disable-next-line
   console.log(`Setting WalletTxHistory as voided from ${txs.length} transactions.`);
   await markWalletTxHistoryAsVoided(mysql, txs);
+  // eslint-disable-next-line
   console.log(`Setting AddressTxHistory as voided from ${txs.length} transactions.`);
   await markAddressTxHistoryAsVoided(mysql, txs);
 
@@ -372,6 +375,7 @@ export const handleVoidedTxList = async (mysql: ServerlessMysql, txs: Tx[]): Pro
 
   // unspend them as the tx_outputs that spent them are now voided
   if (spentOutputs.length > 0) {
+    // eslint-disable-next-line
     console.log(`Unspending ${spentOutputs.length} tx_outputs.`);
     await unspendUtxos(mysql, [...spentOutputs]);
   }
@@ -379,6 +383,7 @@ export const handleVoidedTxList = async (mysql: ServerlessMysql, txs: Tx[]): Pro
   const affectedUtxoList = [...txOutputs, ...spentOutputs];
 
   // mark the tx_outputs from the received tx list as voided
+  // eslint-disable-next-line
   console.log(`Setting ${txOutputs.length} tx_outputs as voided.`);
   await markUtxosAsVoided(mysql, txOutputs);
 
@@ -417,14 +422,17 @@ export const handleVoided = async (mysql: ServerlessMysql, tx: Tx): Promise<void
   // fetch all addresses affected by the voided tx
   const affectedAddresses = affectedUtxoList.reduce((acc: Set<string>, utxo: DbTxOutput) => acc.add(utxo.address), new Set<string>());
 
+  // eslint-disable-next-line
   console.log(`Rebuilding balances for ${affectedAddresses.size} addresses.`);
   if (affectedAddresses.size > 0) {
     const addresses = [...affectedAddresses];
+    // eslint-disable-next-line
     console.log('Addresses:', addresses);
     await rebuildAddressBalancesFromUtxos(mysql, addresses);
     await validateAddressBalances(mysql, addresses);
   }
 
+  // eslint-disable-next-line
   console.log('Handle voided tx is done.');
 };
 
@@ -458,9 +466,11 @@ export const handleReorg = async (mysql: ServerlessMysql): Promise<number> => {
   const { height } = await searchForLatestValidBlock(mysql);
   const currentHeight = await getLatestHeight(mysql);
 
+  // eslint-disable-next-line
   console.log(`Handling reorg. Our latest valid block is ${height} and our highest block height is ${currentHeight}`);
 
   if ((currentHeight - height) > WARN_MAX_REORG_SIZE) {
+    // eslint-disable-next-line
     console.log(`[ALERT] A reorg with ${currentHeight - height} blocks has been detected`);
   }
 
@@ -495,12 +505,14 @@ export const handleReorg = async (mysql: ServerlessMysql): Promise<number> => {
   // get all remaining txs and set height = null (mempool)
   const remainingTxs: Tx[] = await getTxsAfterHeight(mysql, height);
   if (remainingTxs.length > 0) {
+    // eslint-disable-next-line
     console.log(`Setting ${remainingTxs.length} unconfirmed transactions to the mempool (height = NULL).`);
     await removeTxsHeight(mysql, remainingTxs);
   }
 
   // fetch all addresses affected by the reorg
   const affectedAddresses = affectedUtxoList.reduce((acc: Set<string>, utxo: DbTxOutput) => acc.add(utxo.address), new Set<string>());
+  // eslint-disable-next-line
   console.log(`Rebuilding balances for ${affectedAddresses.size} addresses.`);
 
   if (affectedAddresses.size > 0) {
@@ -509,6 +521,7 @@ export const handleReorg = async (mysql: ServerlessMysql): Promise<number> => {
     await validateAddressBalances(mysql, addresses);
   }
 
+  // eslint-disable-next-line
   console.log('Reorg is done.');
 
   return height;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,7 +7,7 @@
 
 import { strict as assert } from 'assert';
 import { ServerlessMysql } from 'serverless-mysql';
-import { constants, walletUtils } from '@hathor/wallet-lib';
+import { constants } from '@hathor/wallet-lib';
 import {
   AddressIndexMap,
   AddressInfo,
@@ -41,6 +41,8 @@ import {
   getUnixTimestamp,
   isAuthority,
   getAddressPath,
+  xpubDeriveChild,
+  getAddresses,
 } from '@src/utils';
 import {
   getWalletFromDbEntry,
@@ -74,10 +76,10 @@ export const generateAddresses = async (mysql: ServerlessMysql, xpubkey: string,
   // We currently generate only addresses in change derivation path 0
   // (more details in https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#Change)
   // so we derive our xpub to this path and use it to get the addresses
-  const derivedXpub = walletUtils.xpubDeriveChild(xpubkey, 0);
+  const derivedXpub = xpubDeriveChild(xpubkey, 0);
 
   do {
-    const addrMap = walletUtils.getAddresses(derivedXpub, highestCheckedIndex + 1, maxGap, process.env.NETWORK);
+    const addrMap = getAddresses(derivedXpub, highestCheckedIndex + 1, maxGap);
     allAddresses.push(...Object.keys(addrMap));
 
     const results: DbSelectResult = await mysql.query(

--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { ServerlessMysql } from 'serverless-mysql';
 import { getWalletId } from '@src/utils';
 import { WalletStatus, Wallet } from '@src/types';

--- a/src/mempool.ts
+++ b/src/mempool.ts
@@ -37,6 +37,7 @@ export const onHandleOldVoidedTxs = async () => {
 
   // Fetch voided transactions that are older than 20m
   const voidedTransactions: Tx[] = await getMempoolTransactionsBeforeDate(mysql, date);
+  // eslint-disable-next-line
   console.log(`Found ${voidedTransactions.length} voided transactions older than ${process.env.VOIDED_TX_OFFSET}m`);
 
   /* This loop will check if all transactions are in fact voided on the fullnode and try to fix it (by updating the height) if

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -122,6 +122,7 @@ export const onNewTxRequest: APIGatewayProxyHandler = async (event) => {
       body: JSON.stringify({ success: true }),
     };
   } catch (e) {
+    // eslint-disable-next-line
     console.log('Errored on onNewTxRequest: ', e);
 
     return {
@@ -150,6 +151,7 @@ export const onHandleReorgRequest: APIGatewayProxyHandler = async () => {
       body: JSON.stringify({ success: true }),
     };
   } catch (e) {
+    // eslint-disable-next-line
     console.log('Errored on onHandleReorgRequest: ', e);
     return {
       statusCode: 500,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,24 +16,6 @@ import * as ecc from 'tiny-secp256k1';
 import BIP32Factory from 'bip32';
 
 const bip32 = BIP32Factory(ecc);
-const hathorNetwork = {
-  mainnet: {
-    messagePrefix: '\x18Hathor Signed Message:\n',
-    bech32: 'ht',
-    bip32: { public: 76067358, private: 55720709 },
-    pubKeyHash: 40,
-    scriptHash: 100,
-    wif: 128,
-  },
-  testnet: {
-    messagePrefix: '\x18Hathor Signed Message:\n',
-    bech32: 'tn',
-    bip32: { public: 76067358, private: 70568132 },
-    pubKeyHash: 40,
-    scriptHash: 100,
-    wif: 128,
-  },
-};
 
 /* TODO: We should remove this as soon as the wallet-lib is refactored
 *  (https://github.com/HathorNetwork/hathor-wallet-lib/issues/122)
@@ -75,6 +57,19 @@ export class CustomStorage {
 
 hathorLib.network.setNetwork(process.env.NETWORK);
 hathorLib.storage.setStore(new CustomStorage());
+
+const libNetwork = hathorLib.network.getNetwork();
+const hathorNetwork = {
+  messagePrefix: '\x18Hathor Signed Message:\n',
+  bech32: hathorLib.network.bech32prefix,
+  bip32: {
+    public: libNetwork.xpubkey,
+    private: libNetwork.xprivkey,
+  },
+  pubKeyHash: libNetwork.pubkeyhash,
+  scriptHash: libNetwork.scripthash,
+  wif: libNetwork.privatekey,
+};
 
 /**
  * Calculate the double sha256 hash of the data.
@@ -271,7 +266,7 @@ export const getAddressAtIndex = (xpubkey: string, addressIndex: number): string
   const node = bip32.fromBase58(xpubkey).derive(addressIndex);
   return bitcoin.payments.p2pkh({
     pubkey: node.publicKey,
-    network: hathorNetwork[process.env.NETWORK || 'mainnet'],
+    network: hathorNetwork,
   }).address;
 };
 
@@ -358,6 +353,6 @@ export const getAddressFromXpub = (xpubkey: string): string => {
 
   return bitcoin.payments.p2pkh({
     pubkey: node.publicKey,
-    network: hathorNetwork[process.env.NETWORK || 'mainnet'],
+    network: hathorNetwork,
   }).address;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,12 +17,22 @@ import BIP32Factory from 'bip32';
 
 const bip32 = BIP32Factory(ecc);
 const hathorNetwork = {
-  messagePrefix: '\x18Hathor Signed Message:\n',
-  bech32: 'ht',
-  bip32: { public: 76067358, private: 55720709 },
-  pubKeyHash: 40,
-  scriptHash: 100,
-  wif: 128,
+  mainnet: {
+    messagePrefix: '\x18Hathor Signed Message:\n',
+    bech32: 'ht',
+    bip32: { public: 76067358, private: 55720709 },
+    pubKeyHash: 40,
+    scriptHash: 100,
+    wif: 128,
+  },
+  testnet: {
+    messagePrefix: '\x18Hathor Signed Message:\n',
+    bech32: 'tn',
+    bip32: { public: 76067358, private: 70568132 },
+    pubKeyHash: 40,
+    scriptHash: 100,
+    wif: 128,
+  },
 };
 
 /* TODO: We should remove this as soon as the wallet-lib is refactored
@@ -253,7 +263,7 @@ export const getAddressAtIndex = (pubkey: string, addressIndex: number): string 
   const node = bip32.fromBase58(pubkey).derive(addressIndex);
   return bitcoin.payments.p2pkh({
     pubkey: node.publicKey,
-    network: hathorNetwork,
+    network: hathorNetwork[process.env.NETWORK || 'mainnet'],
   }).address;
 };
 
@@ -304,6 +314,6 @@ export const getAddressFromXpub = (pubkey: string): string => {
 
   return bitcoin.payments.p2pkh({
     pubkey: node.publicKey,
-    network: hathorNetwork,
+    network: hathorNetwork[process.env.NETWORK || 'mainnet'],
   }).address;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -259,6 +259,14 @@ export const validateAuthTimestamp = (timestamp: number, now: number): [boolean,
   return [timestampShiftInSeconds < AUTH_MAX_TIMESTAMP_SHIFT_IN_SECONDS, timestampShiftInSeconds];
 };
 
+/**
+ * Returns an address from a xpubkey on a specific index
+ *
+ * @param xpubkey - The xpubkey
+ * @param index - The address index to derive
+ *
+ * @returns The derived address
+ */
 export const getAddressAtIndex = (pubkey: string, addressIndex: number): string => {
   const node = bip32.fromBase58(pubkey).derive(addressIndex);
   return bitcoin.payments.p2pkh({
@@ -267,17 +275,46 @@ export const getAddressAtIndex = (pubkey: string, addressIndex: number): string 
   }).address;
 };
 
-export const getAddresses = (pubkey: string, startIndex: number, quantity: number): {[key: string]: number} => {
+/**
+ * Get Hathor addresses in bulk, passing the start index and quantity of addresses to be generated
+ *
+ * @example
+ * ```
+ * getAddresses('myxpub', 2, 3) => {
+ *   'address2': 2,
+ *   'address3': 3,
+ *   'address4': 4,
+ * }
+ * ```
+ *
+ * @param xpubkey The xpubkey
+ * @param startIndex Generate addresses starting from this index
+ * @param quantity Amount of addresses to generate
+ *
+ * @return An object with the generated addresses and corresponding index (string => number)
+ *
+ * @memberof Wallet
+ * @inner
+ */
+export const getAddresses = (xpubkey: string, startIndex: number, quantity: number): {[key: string]: number} => {
   const addrMap = {};
 
   for (let index = startIndex; index < startIndex + quantity; index++) {
-    const address = getAddressAtIndex(pubkey, index);
+    const address = getAddressAtIndex(xpubkey, index);
     addrMap[address] = index;
   }
 
   return addrMap;
 };
 
+/**
+ * Derives a xpubkey at a specific index
+ *
+ * @param xpubkey - The xpubkey
+ * @param index - The index to derive
+ *
+ * @returns The derived xpubkey
+ */
 export const xpubDeriveChild = (pubkey: string, index: number): string => (
   bip32.fromBase58(pubkey).derive(index).toBase58()
 );
@@ -309,8 +346,15 @@ export const verifySignature = (
   }
 };
 
-export const getAddressFromXpub = (pubkey: string): string => {
-  const node = bip32.fromBase58(pubkey);
+/**
+ * Returns an address (as a string) from a string xpubkey
+ *
+ * @param xpubkey - The xpubkey
+ *
+ * @returns the address derived from the xpubkey
+ */
+export const getAddressFromXpub = (xpubkey: string): string => {
+  const node = bip32.fromBase58(xpubkey);
 
   return bitcoin.payments.p2pkh({
     pubkey: node.publicKey,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -267,8 +267,8 @@ export const validateAuthTimestamp = (timestamp: number, now: number): [boolean,
  *
  * @returns The derived address
  */
-export const getAddressAtIndex = (pubkey: string, addressIndex: number): string => {
-  const node = bip32.fromBase58(pubkey).derive(addressIndex);
+export const getAddressAtIndex = (xpubkey: string, addressIndex: number): string => {
+  const node = bip32.fromBase58(xpubkey).derive(addressIndex);
   return bitcoin.payments.p2pkh({
     pubkey: node.publicKey,
     network: hathorNetwork[process.env.NETWORK || 'mainnet'],
@@ -315,8 +315,8 @@ export const getAddresses = (xpubkey: string, startIndex: number, quantity: numb
  *
  * @returns The derived xpubkey
  */
-export const xpubDeriveChild = (pubkey: string, index: number): string => (
-  bip32.fromBase58(pubkey).derive(index).toBase58()
+export const xpubDeriveChild = (xpubkey: string, index: number): string => (
+  bip32.fromBase58(xpubkey).derive(index).toBase58()
 );
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,6 @@ import { createHash, HexBase64Latin1Encoding } from 'crypto';
 
 import serverlessMysql, { ServerlessMysql } from 'serverless-mysql';
 import hathorLib from '@hathor/wallet-lib';
-import bitcore from 'bitcore-lib';
 import fullnode from '@src/fullnode';
 import * as bitcoin from 'bitcoinjs-lib';
 import * as bitcoinMessage from 'bitcoinjs-message';
@@ -221,9 +220,9 @@ export const getAddressPath = (index: number): string => (
  */
 export const confirmFirstAddress = (expectedFirstAddress: string, xpubkey: string): [boolean, string] => {
   // First derive xpub to change 0 path
-  const derivedXpub = hathorLib.walletUtils.xpubDeriveChild(xpubkey, 0);
+  const derivedXpub = xpubDeriveChild(xpubkey, 0);
   // Then get first address
-  const firstAddress = hathorLib.walletUtils.getAddressAtIndex(derivedXpub, 0, process.env.NETWORK);
+  const firstAddress = getAddressAtIndex(derivedXpub, 0);
 
   return [
     firstAddress === expectedFirstAddress,

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -487,6 +487,7 @@ test('POST /wallet', async () => {
   event = makeGatewayEvent({}, JSON.stringify({ param1: 'aaa', firstAddress: 'a' }));
   result = await walletLoad(event, null, null) as APIGatewayProxyResult;
   returnBody = JSON.parse(result.body as string);
+
   expect(result.statusCode).toBe(400);
   expect(returnBody.success).toBe(false);
   expect(returnBody.error).toBe(ApiError.INVALID_PAYLOAD);


### PR DESCRIPTION
## Motivation

I profiled the app using both `bitcore-lib` and `bitcoinjs` and the latter showed a big performance boost on the lambdas using the refactored in this PR. Here are some results:

### authTokenApi

`bitcore-lib`:

```
Duration: 2294.66 ms	Billed Duration: 1591 ms	 Memory Size: 256 MB	Max Memory Used: 98 MB	Init Duration: 703.73 ms
```

`bitcoinjs-lib`:
```
Duration: 596.45 ms	Billed Duration: 597 ms	Memory Size: 256 MB	Max Memory Used: 113 MB
```

### bearerAuthorizer

`bitcore-lib`:

```
Duration: 403.07 ms	Billed Duration: 404 ms	Memory Size: 256 MB	Max Memory Used: 108 MB	
```

`bitcoinjs-lib`:

```
Duration: 23.91 ms	Billed Duration: 24 ms	Memory Size: 256 MB	Max Memory Used: 112 MB
```


### Acceptance Criteria
- We should use bitcoinjs for the following methods, instead of using the `wallet-lib`'s correspondent methods:
  - `getAddressFromXpub`
  - `verifySignature`
  - `xpubDeriveChild`
  - `getAddresses`
  - `getAddressAtIndex`

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
