### PR TITLE
refactor: increase tx history max count

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -81,6 +81,7 @@ provider:
     VOIDED_TX_OFFSET: ${env:VOIDED_TX_OFFSET}
     DEFAULT_SERVER: ${env:DEFAULT_SERVER}
     WS_DOMAIN: ${env:WS_DOMAIN}
+    TX_HISTORY_MAX_COUNT: ${env:TX_HISTORY_MAX_COUNT}
   iamRoleStatements:
     - Effect: Allow
       Action:

--- a/src/api/txhistory.ts
+++ b/src/api/txhistory.ts
@@ -18,8 +18,7 @@ import { closeDbConnection, getDbConnection } from '@src/utils';
 import { walletIdProxyHandler } from '@src/commons';
 import Joi from 'joi';
 
-// XXX add to .env or serverless.yml?
-const MAX_COUNT = 15;
+const MAX_COUNT = parseInt(process.env.TX_HISTORY_MAX_COUNT || '50', 10);
 const htrToken = hathorLib.constants.HATHOR_TOKEN_CONFIG.uid;
 
 const paramsSchema = Joi.object({


### PR DESCRIPTION
# Motivation

The idea behind this PR is to reduce the number of API requests from the desktop wallet by doing a larger first request — we show 10 transactions on transaction history, so we could download 10 pages at once, avoiding 5 subsequent requests

### Acceptance Criteria
- We should increase the `MAX_COUNT` we accept on the `txhistory` API to 50

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
