### PR TITLE
refactor: adding CORs headers to all responses using middy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1433,6 +1433,24 @@
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "dev": true
     },
+    "@middy/core": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-2.5.7.tgz",
+      "integrity": "sha512-KX5Ud0SP+pol6PGkYtMCH4goHobs1XJo3OvEUwdiZUIjZgo56Q08nLu5N7Bs6P+FwGTQHA+hlQ3I5SZbfpO/jg=="
+    },
+    "@middy/http-cors": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@middy/http-cors/-/http-cors-2.5.7.tgz",
+      "integrity": "sha512-YPs5/jL6ujabJ7fo9xCxbsuO0U7cF/eMmtJfghRhJaUzxThuEou1QiXFvtXJwhfT1Rf+69rv36+BE3qAgEG5mg==",
+      "requires": {
+        "@middy/util": "^2.5.7"
+      }
+    },
+    "@middy/util": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/@middy/util/-/util-2.5.7.tgz",
+      "integrity": "sha512-4CwEVfUyvF0n1qtEzrcrV56L7iQYyt6zChYQ9N5/uvQgAhdExLzOinW6ki1ZjTMgaMypqdHNUyDAEiAuNJLRUw=="
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2305,9 +2323,9 @@
       "optional": true
     },
     "@types/aws-lambda": {
-      "version": "8.10.77",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.77.tgz",
-      "integrity": "sha512-n0EMFJU/7u3KvHrR83l/zrKOVURXl5pUJPNED/Bzjah89QKCHwCiKCBoVUXRwTGRfCYGIDdinJaAlKDHZdp/Ng==",
+      "version": "8.10.95",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.95.tgz",
+      "integrity": "sha512-wGtzLbd04EmqhFjTZmXgLzvmhDdyVU7AMo/JkiPmA2VUdBFQfUBQFCEzaVVK+f1PP5aWx1ejnb7K/8MXYI/frQ==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "@hathor/wallet-lib": "^0.31.0",
+    "@middy/core": "^2.5.7",
+    "@middy/http-cors": "^2.5.7",
     "@types/redis": "^2.8.28",
     "aws-lambda": "^1.0.6",
     "aws-sdk": "^2.916.0",
@@ -39,11 +41,12 @@
     "uuid": "^8.3.0"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.76",
+    "@types/aws-lambda": "^8.10.95",
     "@types/jest": "^26.0.24",
     "@types/node": "^10.12.18",
     "@typescript-eslint/eslint-plugin": "^3.3.0",
     "@typescript-eslint/parser": "^3.3.0",
+    "bitcore-lib": "^8.25.25",
     "dotenv": "^10.0.0",
     "eslint": "^7.27.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -66,7 +69,6 @@
     "typescript": "^3.9.5",
     "typescript-eslint": "0.0.1-alpha.0",
     "webpack": "^4.29.0",
-    "webpack-node-externals": "^1.7.2",
-    "bitcore-lib": "^8.25.25"
+    "webpack-node-externals": "^1.7.2"
   }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,15 @@ plugins:
 
 resources:
   Resources:
+    GatewayResponseDefault4XX:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.Access-Control-Allow-Origin: "'*'"
+          gatewayresponse.header.Access-Control-Allow-Headers: "'*'"
+        ResponseType: DEFAULT_4XX
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
     WalletServiceNewTxQueue:
       Type: "AWS::SQS::Queue"
       Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -30,6 +30,9 @@ plugins:
 
 resources:
   Resources:
+    # This is needed to add CORS headers when the authorizer rejects an authorization request
+    # as we don't have control over the response.
+    # Taken from: https://www.serverless.com/blog/cors-api-gateway-survival-guide/
     GatewayResponseDefault4XX:
       Type: 'AWS::ApiGateway::GatewayResponse'
       Properties:

--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -15,8 +15,9 @@ import {
   getWalletAddresses,
 } from '@src/db';
 import { closeDbConnection, getDbConnection } from '@src/utils';
-
 import { walletIdProxyHandler } from '@src/commons';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 
 const mysql = getDbConnection();
 
@@ -25,7 +26,7 @@ const mysql = getDbConnection();
  *
  * This lambda is called by API Gateway on GET /addresses
  */
-export const get: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId) => {
+export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId) => {
   const status = await getWallet(mysql, walletId);
 
   if (!status) {
@@ -43,4 +44,4 @@ export const get: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId)
     statusCode: 200,
     body: JSON.stringify({ success: true, addresses }),
   };
-});
+})).use(cors());

--- a/src/api/balances.ts
+++ b/src/api/balances.ts
@@ -19,6 +19,8 @@ import {
   getDbConnection,
   getUnixTimestamp,
 } from '@src/utils';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 import Joi from 'joi';
 
 const mysql = getDbConnection();
@@ -38,7 +40,7 @@ const paramsSchema = Joi.object({
  * Maybe we should limit the amount of tokens to query the balance to prevent an user
  * with a lot of different tokens in his wallet from doing an expensive query
  */
-export const get: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId, event) => {
+export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId, event) => {
   const params = event.queryStringParameters || {};
 
   const { value, error } = paramsSchema.validate(params, {
@@ -78,4 +80,4 @@ export const get: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId,
     statusCode: 200,
     body: JSON.stringify({ success: true, balances }),
   };
-});
+})).use(cors());

--- a/src/api/miners.ts
+++ b/src/api/miners.ts
@@ -13,6 +13,8 @@ import {
 } from '@src/db';
 import { closeDbConnection, getDbConnection } from '@src/utils';
 import { Miner } from '@src/types';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 
 const mysql = getDbConnection();
 
@@ -23,7 +25,7 @@ const mysql = getDbConnection();
  * @remarks
  * This is a lambda function that should be invoked using the aws-sdk.
  */
-export const onMinersListRequest: APIGatewayProxyHandler = async () => {
+export const onMinersListRequest: APIGatewayProxyHandler = middy(async () => {
   const minersList: Miner[] = await getMinersList(mysql);
 
   await closeDbConnection(mysql);
@@ -35,4 +37,4 @@ export const onMinersListRequest: APIGatewayProxyHandler = async () => {
       miners: minersList,
     }),
   };
-};
+}).use(cors());

--- a/src/api/newAddresses.ts
+++ b/src/api/newAddresses.ts
@@ -17,6 +17,8 @@ import {
 import { closeDbConnection, getDbConnection } from '@src/utils';
 
 import { walletIdProxyHandler } from '@src/commons';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 
 const mysql = getDbConnection();
 
@@ -26,7 +28,7 @@ const mysql = getDbConnection();
  *
  * This lambda is called by API Gateway on GET /addresses/new
  */
-export const get: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId) => {
+export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId) => {
   const status = await getWallet(mysql, walletId);
 
   if (!status) {
@@ -44,4 +46,4 @@ export const get: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId)
     statusCode: 200,
     body: JSON.stringify({ success: true, addresses }),
   };
-});
+})).use(cors());

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -16,6 +16,8 @@ import { ApiError } from '@src/api/errors';
 import { closeDbAndGetError } from '@src/api/utils';
 import Joi from 'joi';
 import { constants } from '@hathor/wallet-lib';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 
 const mysql = getDbConnection();
 
@@ -24,7 +26,7 @@ const mysql = getDbConnection();
  *
  * This lambda is called by API Gateway on GET /wallet/tokens
  */
-export const get = walletIdProxyHandler(async (walletId) => {
+export const get = middy(walletIdProxyHandler(async (walletId) => {
   const walletTokens: string[] = await getWalletTokens(mysql, walletId);
 
   return {
@@ -34,7 +36,7 @@ export const get = walletIdProxyHandler(async (walletId) => {
       tokens: walletTokens,
     }),
   };
-});
+})).use(cors());
 
 const getTokenDetailsParamsSchema = Joi.object({
   token_id: Joi.string()
@@ -47,7 +49,7 @@ const getTokenDetailsParamsSchema = Joi.object({
  *
  * This lambda is called by API Gateway on GET /wallet/tokens/:token_id/details
  */
-export const getTokenDetails = walletIdProxyHandler(async (walletId, event) => {
+export const getTokenDetails = middy(walletIdProxyHandler(async (walletId, event) => {
   const params = event.pathParameters || {};
 
   const { value, error } = getTokenDetailsParamsSchema.validate(params, {
@@ -102,4 +104,4 @@ export const getTokenDetails = walletIdProxyHandler(async (walletId, event) => {
       },
     }),
   };
-});
+})).use(cors());

--- a/src/api/totalSupply.ts
+++ b/src/api/totalSupply.ts
@@ -14,6 +14,8 @@ import {
 } from '@src/db';
 import { closeDbAndGetError } from '@src/api/utils';
 import { closeDbConnection, getDbConnection } from '@src/utils';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 import hathorLib from '@hathor/wallet-lib';
 import Joi from 'joi';
 
@@ -32,7 +34,7 @@ const paramsSchema = Joi.object({
  * @remarks
  * This is a lambda function that should be invoked using the aws-sdk.
  */
-export const onTotalSupplyRequest: APIGatewayProxyHandler = async (event) => {
+export const onTotalSupplyRequest: APIGatewayProxyHandler = middy(async (event) => {
   const { value, error } = paramsSchema.validate(event.body, {
     abortEarly: false,
     convert: true,
@@ -59,4 +61,4 @@ export const onTotalSupplyRequest: APIGatewayProxyHandler = async (event) => {
       totalSupply,
     }),
   };
-};
+}).use(cors());

--- a/src/api/txOutputs.ts
+++ b/src/api/txOutputs.ts
@@ -17,6 +17,8 @@ import {
 import { closeDbAndGetError } from '@src/api/utils';
 import { getDbConnection } from '@src/utils';
 import { constants } from '@hathor/wallet-lib';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 
 const mysql = getDbConnection();
 
@@ -46,7 +48,7 @@ const bodySchema = Joi.object({
  * uses it. As soon as it is updated and we are sure that no users are using that old version, we should remove this
  * API
  */
-export const getFilteredUtxos = walletIdProxyHandler(async (walletId, event) => {
+export const getFilteredUtxos = middy(walletIdProxyHandler(async (walletId, event) => {
   const multiQueryString = event.multiValueQueryStringParameters || {};
   const queryString = event.queryStringParameters || {};
 
@@ -90,14 +92,14 @@ export const getFilteredUtxos = walletIdProxyHandler(async (walletId, event) => 
   }
 
   return response;
-});
+})).use(cors());
 
 /*
  * Filter tx_outputs
  *
  * This lambda is called by API Gateway on GET /wallet/tx_outputs
  */
-export const getFilteredTxOutputs = walletIdProxyHandler(async (walletId, event) => {
+export const getFilteredTxOutputs = middy(walletIdProxyHandler(async (walletId, event) => {
   const multiQueryString = event.multiValueQueryStringParameters || {};
   const queryString = event.queryStringParameters || {};
 
@@ -129,7 +131,7 @@ export const getFilteredTxOutputs = walletIdProxyHandler(async (walletId, event)
   }
 
   return _getFilteredTxOutputs(walletId, value);
-});
+})).use(cors());
 
 const _getFilteredTxOutputs = async (walletId: string, filters: IFilterTxOutput) => {
   const walletAddresses = await getWalletAddresses(mysql, walletId);

--- a/src/api/txProposalCreate.ts
+++ b/src/api/txProposalCreate.ts
@@ -26,6 +26,8 @@ import {
 } from '@src/types';
 import { closeDbAndGetError } from '@src/api/utils';
 import { closeDbConnection, getDbConnection, getUnixTimestamp } from '@src/utils';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 import hathorLib from '@hathor/wallet-lib';
 
 const mysql = getDbConnection();
@@ -39,7 +41,7 @@ const bodySchema = Joi.object({
  *
  * This lambda is called by API Gateway on POST /txproposals
  */
-export const create = walletIdProxyHandler(async (walletId, event) => {
+export const create = middy(walletIdProxyHandler(async (walletId, event) => {
   await maybeRefreshWalletConstants(mysql);
 
   const eventBody = (function parseBody(body) {
@@ -139,7 +141,7 @@ export const create = walletIdProxyHandler(async (walletId, event) => {
       inputs: retInputs,
     }),
   };
-});
+})).use(cors());
 
 /**
  * Confirm that all inputs requested by the user have been fetched.

--- a/src/api/txProposalDestroy.ts
+++ b/src/api/txProposalDestroy.ts
@@ -12,6 +12,8 @@ import { walletIdProxyHandler } from '@src/commons';
 import { TxProposalStatus } from '@src/types';
 import { closeDbConnection, getDbConnection, getUnixTimestamp } from '@src/utils';
 import { closeDbAndGetError } from '@src/api/utils';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 
 const mysql = getDbConnection();
 
@@ -20,7 +22,7 @@ const mysql = getDbConnection();
  *
  * This lambda is called by API Gateway on DELETE /txproposals/{proposalId}
  */
-export const destroy: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId, event) => {
+export const destroy: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId, event) => {
   const params = event.pathParameters;
   let txProposalId: string;
 
@@ -65,4 +67,4 @@ export const destroy: APIGatewayProxyHandler = walletIdProxyHandler(async (walle
       txProposalId,
     }),
   };
-});
+})).use(cors());

--- a/src/api/txProposalSend.ts
+++ b/src/api/txProposalSend.ts
@@ -26,6 +26,8 @@ import {
 } from '@src/commons';
 
 import { closeDbAndGetError } from '@src/api/utils';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 
 const mysql = getDbConnection();
 
@@ -49,7 +51,8 @@ const bodySchema = Joi.object({
  *
  * This lambda is called by API Gateway on PUT /txproposals/{proposalId}
  */
-export const send: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId, event) => {
+export const send: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId, event) => {
+  console.log('Event: ', event);
   if (!event.pathParameters) {
     return closeDbAndGetError(mysql, ApiError.MISSING_PARAMETER, { parameter: 'txProposalId' });
   }
@@ -142,4 +145,4 @@ export const send: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId
       txHex,
     });
   }
-});
+})).use(cors());

--- a/src/api/txhistory.ts
+++ b/src/api/txhistory.ts
@@ -16,6 +16,8 @@ import {
 } from '@src/db';
 import { closeDbConnection, getDbConnection } from '@src/utils';
 import { walletIdProxyHandler } from '@src/commons';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 import Joi from 'joi';
 
 // XXX add to .env or serverless.yml?
@@ -47,7 +49,7 @@ const mysql = getDbConnection();
  *
  * This lambda is called by API Gateway on GET /txhistory
  */
-export const get = walletIdProxyHandler(async (walletId, event) => {
+export const get = middy(walletIdProxyHandler(async (walletId, event) => {
   const params = event.queryStringParameters || {};
 
   const { value, error } = paramsSchema.validate(params, {
@@ -84,4 +86,4 @@ export const get = walletIdProxyHandler(async (walletId, event) => {
     statusCode: 200,
     body: JSON.stringify({ success: true, history, skip, count }),
   };
-});
+})).use(cors());

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -34,6 +34,8 @@ import {
 } from '@src/utils';
 import { closeDbAndGetError } from '@src/api/utils';
 import { walletIdProxyHandler } from '@src/commons';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
 import Joi from 'joi';
 
 const mysql = getDbConnection();
@@ -45,7 +47,7 @@ const MAX_LOAD_WALLET_RETRIES: number = parseInt(process.env.MAX_LOAD_WALLET_RET
  *
  * This lambda is called by API Gateway on GET /wallet
  */
-export const get: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId) => {
+export const get: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId) => {
   const status = await getWallet(mysql, walletId);
   if (!status) {
     return closeDbAndGetError(mysql, ApiError.WALLET_NOT_FOUND);
@@ -57,7 +59,7 @@ export const get: APIGatewayProxyHandler = walletIdProxyHandler(async (walletId)
     statusCode: 200,
     body: JSON.stringify({ success: true, status }),
   };
-});
+})).use(cors());
 
 // If the env requires to validate the first address
 // then we must set the firstAddress field as required
@@ -143,7 +145,7 @@ export const validateSignatures = (
  *
  * This lambda is called by API Gateway on PUT /wallet/auth
  */
-export const changeAuthXpub: APIGatewayProxyHandler = async (event) => {
+export const changeAuthXpub: APIGatewayProxyHandler = middy(async (event) => {
   const eventBody = (function parseBody(body) {
     try {
       return JSON.parse(body);
@@ -238,7 +240,7 @@ export const changeAuthXpub: APIGatewayProxyHandler = async (event) => {
       status: updatedWallet,
     }),
   };
-};
+}).use(cors());
 
 /*
  * Load a wallet. First checks if the wallet doesn't exist already and then call another
@@ -246,7 +248,7 @@ export const changeAuthXpub: APIGatewayProxyHandler = async (event) => {
  *
  * This lambda is called by API Gateway on POST /wallet
  */
-export const load: APIGatewayProxyHandler = async (event) => {
+export const load: APIGatewayProxyHandler = middy(async (event) => {
   const eventBody = (function parseBody(body) {
     try {
       return JSON.parse(body);
@@ -363,7 +365,7 @@ export const load: APIGatewayProxyHandler = async (event) => {
     statusCode: 200,
     body: JSON.stringify({ success: true, status: wallet }),
   };
-};
+}).use(cors());
 
 interface LoadEvent {
   xpubkey: string;

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -5,6 +5,10 @@ import { get as newAddressesGet } from '@src/api/newAddresses';
 import { get as balancesGet } from '@src/api/balances';
 import { get as txHistoryGet } from '@src/api/txhistory';
 import { get as walletTokensGet } from '@src/api/tokens';
+import { create as txProposalCreate } from '@src/api/txProposalCreate';
+import { send as txProposalSend } from '@src/api/txProposalSend';
+import { destroy as txProposalDestroy } from '@src/api/txProposalDestroy';
+import { getFilteredUtxos, getFilteredTxOutputs } from '@src/api/txOutputs';
 import { getTokenDetails } from '@src/api/tokens';
 import {
   get as walletGet,
@@ -116,6 +120,8 @@ test('GET /addresses', async () => {
   // wallet not ready
   await _testWalletNotReady(addressesGet);
 
+  await _testCORSHeaders(addressesGet, 'my-wallet', {});
+
   // success case
   const event = makeGatewayEventWithAuthorizer('my-wallet', {});
   const result = await addressesGet(event, null, null) as APIGatewayProxyResult;
@@ -150,6 +156,8 @@ test('GET /addresses/new', async () => {
 
   // wallet not ready
   await _testWalletNotReady(newAddressesGet);
+
+  await _testCORSHeaders(newAddressesGet, 'some-wallet', {});
 
   // success case
   const event = makeGatewayEventWithAuthorizer('my-wallet', {});
@@ -224,6 +232,9 @@ test('GET /balances', async () => {
 
   // wallet not ready
   await _testWalletNotReady(balancesGet);
+
+  // check CORS headers
+  await _testCORSHeaders(balancesGet, 'my-wallet', {});
 
   // success but no balances
   let event = makeGatewayEventWithAuthorizer('my-wallet', {});
@@ -770,6 +781,13 @@ test('POST /wallet/init should validate attributes properly', async () => {
   expect(returnBody.details[3].message).toStrictEqual('"firstAddress" is required');
 });
 
+test('PUT /wallet/auth', async () => {
+  expect.hasAssertions();
+
+  // check CORS headers
+  await _testCORSHeaders(changeAuthXpub, null, null);
+});
+
 test('PUT /wallet/auth should validate attributes properly', async () => {
   expect.hasAssertions();
 
@@ -1189,4 +1207,34 @@ test('GET /wallet/tokens/token_id/details', async () => {
   expect(returnBody.details.authorities.mint).toStrictEqual(true);
   expect(returnBody.details.authorities.melt).toStrictEqual(true);
   expect(returnBody.details.tokenInfo).toStrictEqual(token2);
+});
+
+test('GET /wallet/utxos', async () => {
+  expect.hasAssertions();
+
+  await _testCORSHeaders(getFilteredUtxos, null, null);
+});
+
+test('GET /wallet/tx_outputs', async () => {
+  expect.hasAssertions();
+
+  await _testCORSHeaders(getFilteredTxOutputs, null, null);
+});
+
+test('POST /tx/proposal', async () => {
+  expect.hasAssertions();
+
+  await _testCORSHeaders(txProposalCreate, null, null);
+});
+
+test('PUT /tx/proposal/{txProposalId}', async () => {
+  expect.hasAssertions();
+
+  await _testCORSHeaders(txProposalSend, null, null);
+});
+
+test('DELETE /tx/proposal/{txProposalId}', async () => {
+  expect.hasAssertions();
+
+  await _testCORSHeaders(txProposalDestroy, null, null);
 });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -646,7 +646,9 @@ export const makeGatewayEventWithAuthorizer = (
   body,
   queryStringParameters: params,
   pathParameters: params,
-  headers: {},
+  headers: {
+    origin: 'https://hathor.com/', // We add this origin to get the access-control-allow-origin header from middy
+  },
   multiValueHeaders: {},
   httpMethod: '',
   isBase64Encoded: false,


### PR DESCRIPTION
# Motivation

The `wallet-desktop` requests to the wallet-service gets a [cross-origin request blocked error](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/CORS/Errors) if the server does not respond with a `Access-Control-Allow-Origin` header on the response

I'm also adding a very nice [middleware library](https://github.com/middyjs/middy) that we can use for other things in the wallet service, like parameter validation, MySQL connection sharing, authorization, and others later on

### Acceptance Criteria
- Our responses should include the `Access-Control-Allow-Origin` header and it should be set to `*`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
