### PR TITLE
feat: added timestamp columns on address_balance table

### DIFF
--- a/db/migrations/20220523151819-address_balance-add-timestamp-fields.js
+++ b/db/migrations/20220523151819-address_balance-add-timestamp-fields.js
@@ -2,13 +2,13 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.addColumn('token', 'created_at', {
+    await queryInterface.addColumn('address_balance', 'created_at', {
       type: 'TIMESTAMP',
       allowNull: false,
       defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
     });
 
-    await queryInterface.addColumn('token', 'updated_at', {
+    await queryInterface.addColumn('address_balance', 'updated_at', {
       type: 'TIMESTAMP',
       allowNull: false,
       defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
@@ -16,7 +16,7 @@ module.exports = {
   },
 
   down: async (queryInterface) => {
-    await queryInterface.removeColumn('token', 'created_at');
-    await queryInterface.removeColumn('token', 'updated_at');
+    await queryInterface.removeColumn('address_balance', 'created_at');
+    await queryInterface.removeColumn('address_balance', 'updated_at');
   },
 };

--- a/db/models/addressbalance.js
+++ b/db/models/addressbalance.js
@@ -60,6 +60,16 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.INTEGER.UNSIGNED,
       allowNull: false,
     },
+    createdAt: {
+      type: 'TIMESTAMP',
+      allowNull: false,
+      defaultValue: DataTypes.literal('CURRENT_TIMESTAMP'),
+    },
+    updatedAt: {
+      type: 'TIMESTAMP',
+      allowNull: false,
+      defaultValue: DataTypes.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+    },
   }, {
     sequelize,
     modelName: 'AddressBalance',

--- a/db/models/token.js
+++ b/db/models/token.js
@@ -33,18 +33,18 @@ module.exports = (sequelize, DataTypes) => {
     createdAt: {
       type: 'TIMESTAMP',
       allowNull: false,
-      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      defaultValue: DataTypes.literal('CURRENT_TIMESTAMP'),
     },
     updatedAt: {
       type: 'TIMESTAMP',
       allowNull: false,
-      defaultValue: Sequelize.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
-    }
+      defaultValue: DataTypes.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
+    },
   }, {
     sequelize,
     modelName: 'Token',
     tableName: 'token',
-    underscored: true
+    underscored: true,
   });
   return Token;
 };


### PR DESCRIPTION
### Acceptance Criteria
- We should have timestamp columns to the `address_balance` table (`created_at`, `updated_at`)
- Values should default to the time the migration ran at (`CURRENT_TIMESTAMP`)


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
