### PR TITLE
fix: rebuild address balances

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2041,6 +2041,7 @@ export const rebuildAddressBalancesFromUtxos = async (
         AND timelock IS NULL
         AND spent_by IS NULL
         AND voided = FALSE
+        AND locked = FALSE
         AND address IN (?)
    GROUP BY address, token_id
   `, [addresses]);
@@ -2068,6 +2069,7 @@ export const rebuildAddressBalancesFromUtxos = async (
            OR \`timelock\` IS NOT NULL)
           AND spent_by IS NULL
           AND voided = FALSE
+          AND locked = TRUE
           AND address IN (?)
      GROUP BY \`address\`, \`token_id\`
    ON DUPLICATE KEY UPDATE

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2037,9 +2037,7 @@ export const rebuildAddressBalancesFromUtxos = async (
             0, -- timelock_expires
             COUNT(DISTINCT \`tx_id\`) -- transactions
        FROM \`tx_output\`
-      WHERE heightlock IS NULL
-        AND timelock IS NULL
-        AND spent_by IS NULL
+      WHERE spent_by IS NULL
         AND voided = FALSE
         AND locked = FALSE
         AND address IN (?)
@@ -2065,9 +2063,7 @@ export const rebuildAddressBalancesFromUtxos = async (
               MIN(\`timelock\`) AS timelock_expires,
               COUNT(DISTINCT \`tx_id\`) -- transactions
          FROM \`tx_output\`
-        WHERE (\`heightlock\` IS NOT NULL
-           OR \`timelock\` IS NOT NULL)
-          AND spent_by IS NULL
+        WHERE spent_by IS NULL
           AND voided = FALSE
           AND locked = TRUE
           AND address IN (?)

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1542,6 +1542,8 @@ test('rebuildAddressBalancesFromUtxos', async () => {
     { value: 5, address: addr1, token: 'token1', locked: false, spentBy: null },
     { value: 15, address: addr1, token: 'token1', locked: false, spentBy: null },
     { value: 25, address: addr2, token: 'token2', timelock: 500, locked: true, spentBy: null },
+    { value: 75, address: addr2, token: 'token1', heightlock: 70, locked: true, spentBy: null },
+    { value: 150, address: addr2, token: 'token1', heightlock: 70, locked: true, spentBy: null },
     { value: 35, address: addr2, token: 'token1', locked: false, spentBy: null },
     // authority utxo
     { value: 0b11, address: addr1, token: 'token1', locked: false, tokenData: 129, spentBy: null },
@@ -1569,8 +1571,9 @@ test('rebuildAddressBalancesFromUtxos', async () => {
   expect(addressBalances[0].tokenId).toStrictEqual('token1');
 
   expect(addressBalances[1].unlockedBalance).toStrictEqual(35);
+  expect(addressBalances[1].lockedBalance).toStrictEqual(225);
   expect(addressBalances[1].address).toStrictEqual(addr2);
-  expect(addressBalances[1].transactions).toStrictEqual(1);
+  expect(addressBalances[1].transactions).toStrictEqual(2);
   expect(addressBalances[1].tokenId).toStrictEqual('token1');
 
   expect(addressBalances[2].lockedBalance).toStrictEqual(25);


### PR DESCRIPTION
## Motivation

Currently, when handling balance recalculations on a re-org, the query is summing values from not only locked utxos, but also from unlocked utxos on the `locked_balance` column.

This PR solves https://github.com/HathorNetwork/hathor-wallet-service/pull/236
(Which also includes a more in-depth explanation of the problem)

### Acceptance Criteria
- We should properly ignore unlocked utxos when recalculating `unlocked_balance` for an address token_id
- We should improve the test case to consider a more real scenario

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
