### PR TITLE
refactor: storing and using highest address index on the wallet table

### DIFF
--- a/db/migrations/20220721003340-wallet_highest_used_index.js
+++ b/db/migrations/20220721003340-wallet_highest_used_index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.addColumn('wallet', 'last_used_address_index', {
+      type: 'INTEGER',
+      allowNull: false,
+      defaultValue: -1,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('wallet', 'last_used_address_index');
+  },
+};

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -403,10 +403,10 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
   const walletId = getWalletId(xpubkey);
 
   try {
-    const { addresses, existingAddresses, newAddresses } = await generateAddresses(mysql, xpubkey, maxGap);
+    const { addresses, existingAddresses, newAddresses, highestUsedIndex } = await generateAddresses(mysql, xpubkey, maxGap);
 
     // update address table with new addresses
-    await addNewAddresses(mysql, walletId, newAddresses);
+    await addNewAddresses(mysql, walletId, newAddresses, highestUsedIndex);
 
     // update existing addresses' walletId and index
     await updateExistingAddresses(mysql, walletId, existingAddresses);

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -403,10 +403,10 @@ export const loadWallet: Handler<LoadEvent, LoadResult> = async (event) => {
   const walletId = getWalletId(xpubkey);
 
   try {
-    const { addresses, existingAddresses, newAddresses, highestUsedIndex } = await generateAddresses(mysql, xpubkey, maxGap);
+    const { addresses, existingAddresses, newAddresses, lastUsedAddressIndex } = await generateAddresses(mysql, xpubkey, maxGap);
 
     // update address table with new addresses
-    await addNewAddresses(mysql, walletId, newAddresses, highestUsedIndex);
+    await addNewAddresses(mysql, walletId, newAddresses, lastUsedAddressIndex);
 
     // update existing addresses' walletId and index
     await updateExistingAddresses(mysql, walletId, existingAddresses);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -70,8 +70,6 @@ const BURN_ADDRESS = 'HDeadDeadDeadDeadDeadDeadDeagTPgmn';
  * @returns Object with all addresses for the given xpubkey and corresponding index
  */
 export const generateAddresses = async (mysql: ServerlessMysql, xpubkey: string, maxGap: number): Promise<GenerateAddresses> => {
-  let highestCheckedIndex = -1;
-  let highestUsedIndex = -1;
   const existingAddresses: AddressIndexMap = {};
   const newAddresses: AddressIndexMap = {};
   const allAddresses: string[] = [];
@@ -81,6 +79,8 @@ export const generateAddresses = async (mysql: ServerlessMysql, xpubkey: string,
   // so we derive our xpub to this path and use it to get the addresses
   const derivedXpub = xpubDeriveChild(xpubkey, 0);
 
+  let highestCheckedIndex = -1;
+  let highestUsedIndex = -1;
   do {
     const addrMap = getAddresses(derivedXpub, highestCheckedIndex + 1, maxGap);
     allAddresses.push(...Object.keys(addrMap));
@@ -127,6 +127,7 @@ export const generateAddresses = async (mysql: ServerlessMysql, xpubkey: string,
     addresses: allAddresses.slice(0, totalAddresses),
     newAddresses,
     existingAddresses,
+    highestUsedIndex,
   };
 };
 
@@ -280,7 +281,12 @@ export const updateWalletAuthXpub = async (
  * @param walletId - The wallet id
  * @param addresses - A map of addresses and corresponding indexes
  */
-export const addNewAddresses = async (mysql: ServerlessMysql, walletId: string, addresses: AddressIndexMap): Promise<void> => {
+export const addNewAddresses = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  addresses: AddressIndexMap,
+  highestUsedIndex: number,
+): Promise<void> => {
   if (Object.keys(addresses).length === 0) return;
   const entries = [];
   for (const [address, index] of Object.entries(addresses)) {
@@ -291,6 +297,14 @@ export const addNewAddresses = async (mysql: ServerlessMysql, walletId: string, 
                              \`wallet_id\`, \`transactions\`)
      VALUES ?`,
     [entries],
+  );
+
+  // Store on the wallet table the highest used index
+  await mysql.query(
+    `UPDATE \`wallet\`
+        SET \`last_used_address_index\` = ?
+      WHERE \`id\` = ?`,
+    [highestUsedIndex, walletId],
   );
 };
 
@@ -1192,26 +1206,17 @@ export const getNewAddresses = async (mysql: ServerlessMysql, walletId: string):
   const resultsWallet: DbSelectResult = await mysql.query('SELECT * FROM `wallet` WHERE `id` = ?', walletId);
   if (resultsWallet.length) {
     const gapLimit = resultsWallet[0].max_gap as number;
+    const latestUsedIndex = resultsWallet[0].last_used_address_index as number;
     // Select all addresses that are empty and the index is bigger than the last used address index
     const results: DbSelectResult = await mysql.query(`
       SELECT *
         FROM \`address\`
        WHERE \`wallet_id\` = ?
          AND \`transactions\` = 0
-         AND \`index\` > (
-           IFNULL(
-             (
-               SELECT MAX(\`index\`)
-                FROM \`address\`
-               WHERE \`wallet_id\` = ?
-                 AND \`transactions\` > 0
-             ),
-             -1
-           )
-         )
+         AND \`index\` > ?
     ORDER BY \`index\`
          ASC
-    LIMIT ?`, [walletId, walletId, gapLimit]);
+    LIMIT ?`, [walletId, latestUsedIndex, gapLimit]);
 
     for (const result of results) {
       const index = result.index as number;

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -340,9 +340,9 @@ const _unsafeAddNewTx = async (_logger: Logger, tx: Transaction, now: number, bl
     // this map might contain duplicate wallet values, as 2 different addresses might belong to the same wallet
     if (seenWallets.has(walletId)) continue;
     seenWallets.add(walletId);
-    const { newAddresses } = await generateAddresses(mysql, wallet.xpubkey, wallet.maxGap);
+    const { newAddresses, highestUsedIndex } = await generateAddresses(mysql, wallet.xpubkey, wallet.maxGap);
     // might need to generate new addresses to keep maxGap
-    await addNewAddresses(mysql, walletId, newAddresses);
+    await addNewAddresses(mysql, walletId, newAddresses, highestUsedIndex);
     // update existing addresses' walletId and index
   }
   // update wallet_balance and wallet_tx_history tables

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -340,9 +340,9 @@ const _unsafeAddNewTx = async (_logger: Logger, tx: Transaction, now: number, bl
     // this map might contain duplicate wallet values, as 2 different addresses might belong to the same wallet
     if (seenWallets.has(walletId)) continue;
     seenWallets.add(walletId);
-    const { newAddresses, highestUsedIndex } = await generateAddresses(mysql, wallet.xpubkey, wallet.maxGap);
+    const { newAddresses, lastUsedAddressIndex } = await generateAddresses(mysql, wallet.xpubkey, wallet.maxGap);
     // might need to generate new addresses to keep maxGap
-    await addNewAddresses(mysql, walletId, newAddresses, highestUsedIndex);
+    await addNewAddresses(mysql, walletId, newAddresses, lastUsedAddressIndex);
     // update existing addresses' walletId and index
   }
   // update wallet_balance and wallet_tx_history tables

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,7 @@ export interface GenerateAddresses {
   addresses: string[];
   existingAddresses: StringMap<number>;
   newAddresses: StringMap<number>;
-  highestUsedIndex: number;
+  lastUsedAddressIndex: number;
 }
 
 export enum TxProposalStatus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,7 @@ export interface GenerateAddresses {
   addresses: string[];
   existingAddresses: StringMap<number>;
   newAddresses: StringMap<number>;
+  highestUsedIndex: number;
 }
 
 export enum TxProposalStatus {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -97,7 +97,15 @@ const _testMissingWallet = async (fn: APIGatewayProxyHandler, walletId: string, 
 
 const _testWalletNotReady = async (fn: APIGatewayProxyHandler) => {
   const walletId = 'wallet-not-started';
-  await addToWalletTable(mysql, [[walletId, 'aaaa', AUTH_XPUBKEY, 'creating', 5, 10000, null]]);
+  await addToWalletTable(mysql, [{
+    id: walletId,
+    xpubkey: 'aaaa',
+    authXpubkey: AUTH_XPUBKEY,
+    status: 'creating',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: null,
+  }]);
   const event = makeGatewayEventWithAuthorizer(walletId, {});
   const result = await fn(event, null, null) as APIGatewayProxyResult;
   const returnBody = JSON.parse(result.body as string);
@@ -109,7 +117,15 @@ const _testWalletNotReady = async (fn: APIGatewayProxyHandler) => {
 test('GET /addresses', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [
     { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0 },
     { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0 },
@@ -140,7 +156,16 @@ test('GET /addresses', async () => {
 test('GET /addresses/new', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    highestUsedIndex: 4,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [
     { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0 },
     { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0 },
@@ -179,7 +204,16 @@ test('GET /addresses/new', async () => {
 test('GET /addresses/new with no transactions', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
+
   await addToAddressTable(mysql, [
     { address: ADDRESSES[0], index: 0, walletId: 'my-wallet', transactions: 0 },
     { address: ADDRESSES[1], index: 1, walletId: 'my-wallet', transactions: 0 },
@@ -217,7 +251,15 @@ test('GET /addresses/new with no transactions', async () => {
 test('GET /balances', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
 
   // add tokens
   const token1 = { id: 'token1', name: 'MyToken1', symbol: 'MT1' };
@@ -402,7 +444,15 @@ test('GET /balances', async () => {
 test('GET /txhistory', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToWalletTxHistoryTable(mysql, [
     ['my-wallet', 'tx1', '00', 5, 1000, false],
     ['my-wallet', 'tx1', 'token2', '7', 1000, false],
@@ -481,7 +531,15 @@ test('GET /txhistory', async () => {
 test('GET /wallet', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', XPUBKEY, AUTH_XPUBKEY, 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: XPUBKEY,
+    authXpubkey: AUTH_XPUBKEY,
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
 
   // check CORS headers
   await _testCORSHeaders(walletGet, 'some-wallet', {});
@@ -879,7 +937,15 @@ test('changeAuthXpub should fail if signatures do not match', async () => {
   expect.hasAssertions();
 
   const walletId = getWalletId(XPUBKEY);
-  await addToWalletTable(mysql, [[walletId, XPUBKEY, AUTH_XPUBKEY, 'creating', 5, 10000, null]]);
+  await addToWalletTable(mysql, [{
+    id: walletId,
+    xpubkey: XPUBKEY,
+    authXpubkey: AUTH_XPUBKEY,
+    status: 'creating',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: null,
+  }]);
 
   const event = makeGatewayEvent({}, JSON.stringify({
     xpubkey: XPUBKEY,
@@ -1118,7 +1184,15 @@ test('loadWallet should update wallet status to ERROR if an error occurs', async
 test('GET /wallet/tokens', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToWalletTxHistoryTable(mysql, [
     ['my-wallet', 'tx1', '00', 5, 1000, false],
     ['my-wallet', 'tx1', 'token2', '7', 1000, false],
@@ -1144,7 +1218,15 @@ test('GET /wallet/tokens/token_id/details', async () => {
   // check CORS headers
   await _testCORSHeaders(getTokenDetails, null, null);
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
 
   let event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: 'unknown' });
   let result = await getTokenDetails(event, null, null) as APIGatewayProxyResult;

--- a/tests/commons.test.ts
+++ b/tests/commons.test.ts
@@ -218,9 +218,15 @@ test('unlockUtxos', async () => {
     [txId5, 0, token, addr, 0, 0b10, now * 3, null, true, null],
   ]);
 
-  await addToWalletTable(mysql, [
-    [walletId, 'xpub', 'auth_xpubkey', 'ready', 10, now, now + 1],
-  ]);
+  await addToWalletTable(mysql, [{
+    id: walletId,
+    xpubkey: 'xpub',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 10,
+    createdAt: now,
+    readyAt: now + 1,
+  }]);
 
   await addToAddressTable(mysql, [{
     address: addr,
@@ -329,9 +335,15 @@ test('unlockTimelockedUtxos', async () => {
     [txId3, 0, token, addr, 0, 0b10, now * 3, null, true, null],
   ]);
 
-  await addToWalletTable(mysql, [
-    [walletId, 'xpub', 'auth_xpubkey', 'ready', 10, now, now + 1],
-  ]);
+  await addToWalletTable(mysql, [{
+    id: walletId,
+    xpubkey: 'xpub',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 10,
+    createdAt: now,
+    readyAt: now + 1,
+  }]);
 
   await addToAddressTable(mysql, [{
     address: addr,

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -244,7 +244,15 @@ test('getAddressWalletInfo', async () => {
     await mysql.query('INSERT INTO `wallet` SET ? ON DUPLICATE KEY UPDATE id=id', [entry]);
   }
   // add wallet that should not be on the results
-  await addToWalletTable(mysql, [['wallet3', 'xpubkey3', 'authxpubkey3', WalletStatus.READY, 5, 0, 0]]);
+  await addToWalletTable(mysql, [{
+    id: 'wallet3',
+    xpubkey: 'xpubkey3',
+    authXpubkey: 'authxpubkey3',
+    status: WalletStatus.READY,
+    maxGap: 5,
+    createdAt: 0,
+    readyAt: 0,
+  }]);
 
   const addressWalletMap = await getAddressWalletInfo(mysql, Object.keys(finalMap));
   expect(addressWalletMap).toStrictEqual(finalMap);
@@ -298,11 +306,11 @@ test('addNewAddresses', async () => {
   const walletId = 'walletId';
 
   // test adding empty dict
-  await addNewAddresses(mysql, walletId, {});
+  await addNewAddresses(mysql, walletId, {}, -1);
   await expect(checkAddressTable(mysql, 0)).resolves.toBe(true);
 
   // add some addresses
-  await addNewAddresses(mysql, walletId, addrMap);
+  await addNewAddresses(mysql, walletId, addrMap, -1);
   for (const [index, address] of ADDRESSES.entries()) {
     await expect(checkAddressTable(mysql, ADDRESSES.length, address, index, walletId, 0)).resolves.toBe(true);
   }
@@ -321,7 +329,7 @@ test('updateExistingAddresses', async () => {
   for (const address of ADDRESSES) {
     newAddrMap[address] = null;
   }
-  await addNewAddresses(mysql, null, newAddrMap);
+  await addNewAddresses(mysql, null, newAddrMap, -1);
   for (const address of ADDRESSES) {
     await expect(checkAddressTable(mysql, ADDRESSES.length, address, null, null, 0)).resolves.toBe(true);
   }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -150,6 +150,8 @@ test('generateAddresses', async () => {
   addressesInfo = await generateAddresses(mysql, XPUBKEY, maxGap);
   expect(addressesInfo.addresses).toHaveLength(maxGap);
   expect(addressesInfo.existingAddresses).toStrictEqual({ [address0]: 0 });
+  expect(addressesInfo.lastUsedAddressIndex).toStrictEqual(-1);
+
   let totalLength = Object.keys(addressesInfo.addresses).length;
   let existingLength = Object.keys(addressesInfo.existingAddresses).length;
   expect(Object.keys(addressesInfo.newAddresses)).toHaveLength(totalLength - existingLength);
@@ -161,6 +163,8 @@ test('generateAddresses', async () => {
   addressesInfo = await generateAddresses(mysql, XPUBKEY, maxGap);
   expect(addressesInfo.addresses).toHaveLength(maxGap + usedIndex + 1);
   expect(addressesInfo.existingAddresses).toStrictEqual({ [address0]: 0 });
+  expect(addressesInfo.lastUsedAddressIndex).toStrictEqual(0);
+
   totalLength = Object.keys(addressesInfo.addresses).length;
   existingLength = Object.keys(addressesInfo.existingAddresses).length;
   expect(Object.keys(addressesInfo.newAddresses)).toHaveLength(totalLength - existingLength);
@@ -177,6 +181,7 @@ test('generateAddresses', async () => {
   addressesInfo = await generateAddresses(mysql, XPUBKEY, maxGap);
   expect(addressesInfo.addresses).toHaveLength(maxGap + usedIndex + 1);
   expect(addressesInfo.existingAddresses).toStrictEqual({ [address0]: 0, [address1]: 1 });
+  expect(addressesInfo.lastUsedAddressIndex).toStrictEqual(1);
   totalLength = Object.keys(addressesInfo.addresses).length;
   existingLength = Object.keys(addressesInfo.existingAddresses).length;
   expect(Object.keys(addressesInfo.newAddresses)).toHaveLength(totalLength - existingLength);
@@ -193,6 +198,7 @@ test('generateAddresses', async () => {
   addressesInfo = await generateAddresses(mysql, XPUBKEY, maxGap);
   expect(addressesInfo.addresses).toHaveLength(maxGap + usedIndex + 1);
   expect(addressesInfo.existingAddresses).toStrictEqual({ [address0]: 0, [address1]: 1, [address4]: 4 });
+  expect(addressesInfo.lastUsedAddressIndex).toStrictEqual(4);
   totalLength = Object.keys(addressesInfo.addresses).length;
   existingLength = Object.keys(addressesInfo.existingAddresses).length;
   expect(Object.keys(addressesInfo.newAddresses)).toHaveLength(totalLength - existingLength);

--- a/tests/txOutputs.test.ts
+++ b/tests/txOutputs.test.ts
@@ -28,7 +28,15 @@ afterAll(async () => {
 test('filter utxos api with invalid parameters', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -110,7 +118,16 @@ test('filter utxos api with invalid parameters', async () => {
 test('filter tx_output api with invalid parameters', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
+
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -192,7 +209,15 @@ test('filter tx_output api with invalid parameters', async () => {
 test('get utxos with wallet id', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -251,7 +276,15 @@ test('get utxos with wallet id', async () => {
 test('get tx outputs with wallet id', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -310,7 +343,15 @@ test('get tx outputs with wallet id', async () => {
 test('get authority utxos', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -382,7 +423,15 @@ test('get authority utxos', async () => {
 test('get a specific utxo', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -439,7 +488,15 @@ test('get a specific utxo', async () => {
 test('get utxos from addresses that are not my own should fail with ApiError.ADDRESS_NOT_IN_WALLET', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -478,7 +535,15 @@ test('get utxos from addresses that are not my own should fail with ApiError.ADD
 test('get spent tx_output', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,

--- a/tests/txProcessor.test.ts
+++ b/tests/txProcessor.test.ts
@@ -58,9 +58,15 @@ test('spend "locked" utxo', async () => {
   const timelock = 1000;
   const maxGap = parseInt(process.env.MAX_ADDRESS_GAP, 10);
 
-  await addToWalletTable(mysql, [
-    [walletId, XPUBKEY, AUTH_XPUBKEY, 'ready', 10, 1, 2],
-  ]);
+  await addToWalletTable(mysql, [{
+    id: walletId,
+    xpubkey: XPUBKEY,
+    authXpubkey: AUTH_XPUBKEY,
+    status: 'ready',
+    maxGap: 10,
+    createdAt: 1,
+    readyAt: 2,
+  }]);
 
   await addToUtxoTable(mysql, [
     // we received a tx that has timelock
@@ -240,9 +246,15 @@ test('txProcessor should ignore NFT outputs', async () => {
   const walletId = 'walletId';
   const timelock = 1000;
 
-  await addToWalletTable(mysql, [
-    [walletId, XPUBKEY, AUTH_XPUBKEY, 'ready', 10, 1, 2],
-  ]);
+  await addToWalletTable(mysql, [{
+    id: walletId,
+    xpubkey: XPUBKEY,
+    authXpubkey: AUTH_XPUBKEY,
+    status: 'ready',
+    maxGap: 10,
+    createdAt: 1,
+    readyAt: 2,
+  }]);
 
   await addToUtxoTable(mysql, [
     [txId1, 0, '00', addr, 41, 0, null, null, false, null],
@@ -351,9 +363,15 @@ test('onHandleVoidedTxRequest', async () => {
   const walletId = 'walletId';
   const timelock = 1000;
 
-  await addToWalletTable(mysql, [
-    [walletId, XPUBKEY, AUTH_XPUBKEY, 'ready', 10, 1, 2],
-  ]);
+  await addToWalletTable(mysql, [{
+    id: walletId,
+    xpubkey: XPUBKEY,
+    authXpubkey: AUTH_XPUBKEY,
+    status: 'ready',
+    maxGap: 10,
+    createdAt: 1,
+    readyAt: 2,
+  }]);
 
   await addToUtxoTable(mysql, [
     [txId1, 0, token, addr, 2500, 0, null, null, false, null],

--- a/tests/txProposal.test.ts
+++ b/tests/txProposal.test.ts
@@ -80,7 +80,15 @@ test('POST /txproposals with null as param should fail with ApiError.INVALID_PAY
 test('POST /txproposals with utxos that are already used on another txproposal should fail with ApiError.INPUTS_ALREADY_USED', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -180,7 +188,15 @@ test('POST /txproposals with too many outputs should fail with ApiError.TOO_MANY
     maxNumberOutputs: 2, // mocking to force a failure
   });
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -221,7 +237,15 @@ test('POST /txproposals with too many outputs should fail with ApiError.TOO_MANY
 test('POST /txproposals with a wallet that is not ready should fail with ApiError.WALLET_NOT_READY', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['not-ready-wallet', 'xpubkey', 'auth_xpubkey', 'creating', 5, 10000, null]]);
+  await addToWalletTable(mysql, [{
+    id: 'not-ready-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'creating',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: null,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -273,7 +297,15 @@ test('POST /txproposals with a wallet that is not ready should fail with ApiErro
 test('PUT /txproposals/{proposalId} with an empty body should fail with ApiError.INVALID_PAYLOAD', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -377,7 +409,15 @@ test('PUT /txproposals/{proposalId} with a invalid proposalId should fail with A
 test('PUT /txproposals/{proposalId} on a proposal which status is not OPEN or SEND_ERROR should fail with ApiError.TX_PROPOSAL_NOT_OPEN', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -465,7 +505,15 @@ test('PUT /txproposals/{proposalId} on a proposal which status is not OPEN or SE
 test('PUT /txproposals/{proposalId} on a proposal which is not owned by the user\'s wallet should fail with ApiError.FORBIDDEN', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -577,7 +625,15 @@ test('PUT /txproposals/{proposalId} with an invalid txHex should fail and update
     }),
   });
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -683,7 +739,15 @@ test('PUT /txproposals/{proposalId} should update tx_proposal to SEND_ERROR on f
     }),
   });
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -766,7 +830,15 @@ test('PUT /txproposals/{proposalId} should update tx_proposal to SEND_ERROR on f
 test('DELETE /txproposals/{proposalId} should delete a tx_proposal and remove the utxos associated to it', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -899,7 +971,15 @@ test('DELETE /txproposals/{proposalId} should fail with ApiError.TX_PROPOSAL_NOT
 test('POST /txproposals one output and input on txHex', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -977,8 +1057,24 @@ test('POST /txproposals one output and input on txHex', async () => {
 test('POST /txproposals with denied utxos', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
-  await addToWalletTable(mysql, [['other-wallet', 'xpubkey', 'auth_xpubkey2', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
+  await addToWalletTable(mysql, [{
+    id: 'other-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey2',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -1031,7 +1127,15 @@ test('POST /txproposals with denied utxos', async () => {
 test('POST /txproposals a tx create action on txHex', async () => {
   expect.hasAssertions();
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -1148,7 +1252,15 @@ test('PUT /txproposals/{proposalId} with txhex', async () => {
     }),
   });
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,
@@ -1251,7 +1363,15 @@ test('PUT /txproposals/{proposalId} with a different txhex than the one sent in 
     }),
   });
 
-  await addToWalletTable(mysql, [['my-wallet', 'xpubkey', 'auth_xpubkey', 'ready', 5, 10000, 10001]]);
+  await addToWalletTable(mysql, [{
+    id: 'my-wallet',
+    xpubkey: 'xpubkey',
+    authXpubkey: 'auth_xpubkey',
+    status: 'ready',
+    maxGap: 5,
+    createdAt: 10000,
+    readyAt: 10001,
+  }]);
   await addToAddressTable(mysql, [{
     address: ADDRESSES[0],
     index: 0,

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -30,3 +30,14 @@ export interface TokenTableEntry {
   name: string;
   symbol: string;
 }
+
+export interface WalletTableEntry {
+  id: string;
+  xpubkey: string;
+  authXpubkey: string;
+  status: string;
+  maxGap: number;
+  highestUsedIndex?: number;
+  createdAt: number;
+  readyAt: number;
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -8,7 +8,7 @@ import {
 } from '@src/types';
 import { getWalletId } from '@src/utils';
 import { walletUtils, network, HathorWalletServiceWallet } from '@hathor/wallet-lib';
-import { WalletBalanceEntry, AddressTableEntry, TokenTableEntry } from '@tests/types';
+import { WalletBalanceEntry, AddressTableEntry, TokenTableEntry, WalletTableEntry } from '@tests/types';
 import { RedisClient } from 'redis';
 import bitcore from 'bitcore-lib';
 
@@ -498,15 +498,26 @@ export const addToUtxoTable = async (
 
 export const addToWalletTable = async (
   mysql: ServerlessMysql,
-  entries: unknown[][],
+  entries: WalletTableEntry[],
 ): Promise<void> => {
+  const payload = entries.map((entry) => [
+    entry.id,
+    entry.xpubkey,
+    entry.highestUsedIndex || -1,
+    entry.authXpubkey,
+    entry.status,
+    entry.maxGap,
+    entry.createdAt,
+    entry.readyAt,
+  ]);
   await mysql.query(`
     INSERT INTO \`wallet\`(\`id\`, \`xpubkey\`,
+                           \`last_used_address_index\`,
                            \`auth_xpubkey\`,
                            \`status\`, \`max_gap\`,
                            \`created_at\`, \`ready_at\`)
     VALUES ?`,
-  [entries]);
+  [payload]);
 };
 
 export const addToWalletBalanceTable = async (


### PR DESCRIPTION
### Acceptance Criteria
- We should store the highest used address index on the wallet table every time we generate new addresses
- We should use the highest used address on the `getNewAddresses` query to prevent a query on the big address table


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
