### PR TITLE
fix: re-calculating the transactions count correctly on a reorg or vo…

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -29,7 +29,7 @@ import {
 import middy from '@middy/core';
 import cors from '@middy/http-cors';
 
-const EXPIRATION_TIME_IN_SECONDS = 1800;
+const EXPIRATION_TIME_IN_SECONDS = 180;
 
 const bodySchema = Joi.object({
   ts: Joi.number().positive().required(),

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -29,7 +29,7 @@ import {
 import middy from '@middy/core';
 import cors from '@middy/http-cors';
 
-const EXPIRATION_TIME_IN_SECONDS = 180;
+const EXPIRATION_TIME_IN_SECONDS = 1800;
 
 const bodySchema = Joi.object({
   ts: Joi.number().positive().required(),

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -429,7 +429,7 @@ export const handleVoided = async (mysql: ServerlessMysql, logger: Logger, tx: T
     affectedUtxoList = [...affectedUtxoList, ...newAffectedUtxoList];
   }
 
-  // fetch all addresses affected by the voided tx
+  // fetch all addresses and transactions affected by the voided transaction
   const [affectedAddresses, affectedTxIds] = affectedUtxoList.reduce(
     (acc: [Set<string>, Set<string>], utxo: DbTxOutput) => {
       acc[0].add(utxo.address);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2498,6 +2498,15 @@ export const getAvailableAuthorities = async (
   return utxos;
 };
 
+/**
+ * Get the number of transactions for each token from the address_tx_history table
+ * given a list of transactions
+ *
+ * @param mysql - Database connection
+ * @param txList - A list of affected transactions to get the addresses token transaction count
+
+ * @returns A Map with address_tokenId as key and the transaction count as values
+ */
 export const getAffectedAddressTxCountFromTxList = async (
   mysql: ServerlessMysql,
   txList: string[],

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2515,6 +2515,7 @@ export const getAffectedAddressTxCountFromTxList = async (
     SELECT address, COUNT(DISTINCT(tx_id)) AS txCount, token_id as tokenId
       FROM address_tx_history 
      WHERE tx_id IN (?)
+       AND voided = TRUE
   GROUP BY address, token_id
   `, [txList]);
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2110,9 +2110,9 @@ export const rebuildAddressBalancesFromUtxos = async (
        WHERE \`address\` = ?
          AND \`token_id\` = ?
     `, [
+      addressTokenTx[2],
       addressTokenTx[0],
       addressTokenTx[1],
-      addressTokenTx[2],
     ]);
   }
 };

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1265,9 +1265,9 @@ test('GET /wallet/tokens/token_id/details', async () => {
   ]);
 
   await addToAddressTxHistoryTable(mysql, [
-    [ADDRESSES[0], 'txId', token1.id, 100, 0],
-    [ADDRESSES[0], 'txId2', token2.id, 250, 0],
-    [ADDRESSES[0], 'txId3', token2.id, 0, 0],
+    { address: ADDRESSES[0], txId: 'txId', tokenId: token1.id, balance: 100, timestamp: 0 },
+    { address: ADDRESSES[0], txId: 'txId2', tokenId: token2.id, balance: 250, timestamp: 0 },
+    { address: ADDRESSES[0], txId: 'txId3', tokenId: token2.id, balance: 0, timestamp: 0 },
   ]);
 
   event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: token1.id });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2104,25 +2104,10 @@ test('getAffectedAddressTxCountFromTxList', async () => {
 
   const result = await getAffectedAddressTxCountFromTxList(mysql, [txId1, txId3]);
 
-  expect(result).toStrictEqual([{
-    address: addr1,
-    transactions: 1,
-    tokenId: token1,
-    balance: 0,
-  }, {
-    address: addr1,
-    transactions: 1,
-    tokenId: token2,
-    balance: 0,
-  }, {
-    address: addr2,
-    transactions: 2,
-    tokenId: token2,
-    balance: 0,
-  }, {
-    address: addr3,
-    transactions: 2,
-    tokenId: token1,
-    balance: 0,
-  }]);
+  expect(result).toStrictEqual({
+    [`${addr1}_${token1}`]: 1,
+    [`${addr1}_${token2}`]: 1,
+    [`${addr2}_${token2}`]: 2,
+    [`${addr3}_${token1}`]: 2,
+  });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -110,6 +110,7 @@ import {
   createInput,
   countTxOutputTable,
 } from '@tests/utils';
+import { AddressTxHistoryTableEntry } from '@tests/types';
 
 import { constants } from '@hathor/wallet-lib';
 
@@ -391,14 +392,14 @@ test('initWalletTxHistory', async () => {
   await expect(checkWalletTxHistoryTable(mysql, 0)).resolves.toBe(true);
 
   const entries = [
-    [addr1, txId1, token1, 10, timestamp1],
-    [addr1, txId1, token2, 7, timestamp1],
-    [addr2, txId1, token2, 5, timestamp1],
-    [addr3, txId1, token1, 3, timestamp1],
-    [addr1, txId2, token1, -1, timestamp2],
-    [addr1, txId2, token3, 3, timestamp2],
-    [addr2, txId2, token2, -5, timestamp2],
-    [addr3, txId2, token1, 3, timestamp2],
+    { address: addr1, txId: txId1, tokenId: token1, balance: 10, timestamp: timestamp1 },
+    { address: addr1, txId: txId1, tokenId: token2, balance: 7, timestamp: timestamp1 },
+    { address: addr2, txId: txId1, tokenId: token2, balance: 5, timestamp: timestamp1 },
+    { address: addr3, txId: txId1, tokenId: token1, balance: 3, timestamp: timestamp1 },
+    { address: addr1, txId: txId2, tokenId: token1, balance: -1, timestamp: timestamp2 },
+    { address: addr1, txId: txId2, tokenId: token3, balance: 3, timestamp: timestamp2 },
+    { address: addr2, txId: txId2, tokenId: token2, balance: -5, timestamp: timestamp2 },
+    { address: addr3, txId: txId2, tokenId: token1, balance: 3, timestamp: timestamp2 },
   ];
   await addToAddressTxHistoryTable(mysql, entries);
 
@@ -433,14 +434,14 @@ test('initWalletBalance', async () => {
    * address to make sure the wallet will only get the balance from its own addresses
    */
   const historyEntries = [
-    [addr1, tx1, token1, 10, ts1],
-    [addr1, tx2, token1, -8, ts2],
-    [addr1, tx1, token2, 5, ts1],
-    [addr2, tx1, token1, 3, ts1],
-    [addr2, tx3, token1, 4, ts3],
-    [addr2, tx2, token2, 2, ts2],
-    [addr3, tx1, token1, 1, ts1],
-    [addr3, tx3, token2, 11, ts3],
+    { address: addr1, txId: tx1, tokenId: token1, balance: 10, timestamp: ts1 },
+    { address: addr1, txId: tx2, tokenId: token1, balance: -8, timestamp: ts2 },
+    { address: addr1, txId: tx1, tokenId: token2, balance: 5, timestamp: ts1 },
+    { address: addr2, txId: tx1, tokenId: token1, balance: 3, timestamp: ts1 },
+    { address: addr2, txId: tx3, tokenId: token1, balance: 4, timestamp: ts3 },
+    { address: addr2, txId: tx2, tokenId: token2, balance: 2, timestamp: ts2 },
+    { address: addr3, txId: tx1, tokenId: token1, balance: 1, timestamp: ts1 },
+    { address: addr3, txId: tx3, tokenId: token2, balance: 11, timestamp: ts3 },
   ];
   const addressEntries = [
     // address, tokenId, unlocked, locked, lockExpires, transactions
@@ -1428,13 +1429,13 @@ test('fetchAddressTxHistorySum', async () => {
   const timestamp1 = 10;
   const timestamp2 = 20;
   const entries = [
-    [addr1, txId1, token1, 10, timestamp1],
-    [addr1, txId2, token1, 20, timestamp2],
-    [addr1, txId3, token1, 30, timestamp2],
+    { address: addr1, txId: txId1, tokenId: token1, balance: 10, timestamp: timestamp1 },
+    { address: addr1, txId: txId2, tokenId: token1, balance: 20, timestamp: timestamp2 },
+    { address: addr1, txId: txId3, tokenId: token1, balance: 30, timestamp: timestamp2 },
     // total: 60
-    [addr2, txId1, token2, 20, timestamp1],
-    [addr2, txId2, token2, 20, timestamp2],
-    [addr2, txId3, token2, 10, timestamp2],
+    { address: addr2, txId: txId1, tokenId: token2, balance: 20, timestamp: timestamp1 },
+    { address: addr2, txId: txId2, tokenId: token2, balance: 20, timestamp: timestamp2 },
+    { address: addr2, txId: txId3, tokenId: token2, balance: 10, timestamp: timestamp2 },
     // total: 50
   ];
 
@@ -1621,13 +1622,13 @@ test('rebuildAddressBalancesFromUtxos', async () => {
   await addToAddressBalanceTable(mysql, addressEntries);
 
   const txHistory = [
-    [addr1, txId, token1, 20, timestamp1],
-    [addr1, txId4, token1, 21, timestamp1],
+    { address: addr1, txId, tokenId: token1, balance: 20, timestamp: timestamp1 },
+    { address: addr1, txId: txId4, tokenId: token1, balance: 21, timestamp: timestamp1 },
 
-    [addr2, txId, token1, 260, timestamp1],
-    [addr2, txId, token2, 25, timestamp1],
-    [addr2, txId2, token1, 80, timestamp1],
-    [addr2, txId3, token1, 15, timestamp1],
+    { address: addr2, txId, tokenId: token1, balance: 260, timestamp: timestamp1 },
+    { address: addr2, txId, tokenId: token2, balance: 25, timestamp: timestamp1 },
+    { address: addr2, txId: txId2, tokenId: token1, balance: 80, timestamp: timestamp1 },
+    { address: addr2, txId: txId3, tokenId: token1, balance: 15, timestamp: timestamp1 },
   ];
 
   await addToAddressTxHistoryTable(mysql, txHistory);
@@ -1670,13 +1671,13 @@ test('markAddressTxHistoryAsVoided', async () => {
   const timestamp2 = 20;
 
   const entries = [
-    [addr1, txId1, token1, 10, timestamp1],
-    [addr1, txId2, token1, 20, timestamp2],
-    [addr1, txId3, token1, 30, timestamp2],
+    { address: addr1, txId: txId1, tokenId: token1, balance: 10, timestamp: timestamp1 },
+    { address: addr1, txId: txId2, tokenId: token1, balance: 20, timestamp: timestamp2 },
+    { address: addr1, txId: txId3, tokenId: token1, balance: 30, timestamp: timestamp2 },
     // total: 60
-    [addr2, txId1, token2, 20, timestamp1],
-    [addr2, txId2, token2, 20, timestamp2],
-    [addr2, txId3, token2, 10, timestamp2],
+    { address: addr2, txId: txId1, tokenId: token2, balance: 20, timestamp: timestamp1 },
+    { address: addr2, txId: txId2, tokenId: token2, balance: 20, timestamp: timestamp2 },
+    { address: addr2, txId: txId3, tokenId: token2, balance: 10, timestamp: timestamp2 },
     // total: 50
   ];
 
@@ -1986,11 +1987,11 @@ test('getTotalTransactions', async () => {
   expect.hasAssertions();
 
   await addToAddressTxHistoryTable(mysql, [
-    ['address1', 'txId1', 'token1', -5, 1000],
-    ['address1', 'txId2', 'token1', 5, 1000],
-    ['address1', 'txId3', 'token1', 10, 1000],
-    ['address2', 'txId4', 'token2', -5, 1000],
-    ['address2', 'txId5', 'token2', 50, 1000],
+    { address: 'address1', txId: 'txId1', tokenId: 'token1', balance: -5, timestamp: 1000 },
+    { address: 'address1', txId: 'txId2', tokenId: 'token1', balance: 5, timestamp: 1000 },
+    { address: 'address1', txId: 'txId3', tokenId: 'token1', balance: 10, timestamp: 1000 },
+    { address: 'address2', txId: 'txId4', tokenId: 'token2', balance: -5, timestamp: 1000 },
+    { address: 'address2', txId: 'txId5', tokenId: 'token2', balance: 50, timestamp: 1000 },
   ]);
 
   expect(await getTotalTransactions(mysql, 'token1')).toStrictEqual(3);
@@ -2089,25 +2090,34 @@ test('getAffectedAddressTxCountFromTxList', async () => {
   const timestamp1 = 10;
   const timestamp2 = 20;
 
-  const entries = [
-    [addr1, txId1, token1, 10, timestamp1],
-    [addr1, txId1, token2, 7, timestamp1],
-    [addr2, txId1, token2, 5, timestamp1],
-    [addr3, txId1, token1, 3, timestamp1],
-    [addr1, txId2, token1, -1, timestamp2],
-    [addr1, txId2, token3, 3, timestamp2],
-    [addr2, txId3, token2, -5, timestamp2],
-    [addr3, txId3, token1, 3, timestamp2],
+  const entries: AddressTxHistoryTableEntry[] = [
+    { address: addr1, txId: txId1, tokenId: token1, balance: 10, timestamp: timestamp1, voided: true },
+    { address: addr1, txId: txId1, tokenId: token2, balance: 7, timestamp: timestamp1, voided: true },
+    { address: addr2, txId: txId1, tokenId: token2, balance: 5, timestamp: timestamp1, voided: true },
+    { address: addr3, txId: txId1, tokenId: token1, balance: 3, timestamp: timestamp1, voided: true },
+    { address: addr1, txId: txId2, tokenId: token1, balance: -1, timestamp: timestamp2, voided: false },
+    { address: addr1, txId: txId2, tokenId: token3, balance: 3, timestamp: timestamp2, voided: false },
+    { address: addr2, txId: txId3, tokenId: token2, balance: -5, timestamp: timestamp2, voided: true },
+    { address: addr3, txId: txId3, tokenId: token1, balance: 3, timestamp: timestamp2, voided: true },
   ];
 
   await addToAddressTxHistoryTable(mysql, entries);
 
-  const result = await getAffectedAddressTxCountFromTxList(mysql, [txId1, txId3]);
-
-  expect(result).toStrictEqual({
+  expect(await getAffectedAddressTxCountFromTxList(mysql, [txId1, txId3])).toStrictEqual({
     [`${addr1}_${token1}`]: 1,
     [`${addr1}_${token2}`]: 1,
     [`${addr2}_${token2}`]: 2,
     [`${addr3}_${token1}`]: 2,
   });
+
+  // txId2 is not voided, so we should not count them on the address transaction count:
+  expect(await getAffectedAddressTxCountFromTxList(mysql, [txId1, txId2, txId3])).toStrictEqual({
+    [`${addr1}_${token1}`]: 1,
+    [`${addr1}_${token2}`]: 1,
+    [`${addr2}_${token2}`]: 2,
+    [`${addr3}_${token1}`]: 2,
+  });
+
+  // We should get an empty object if no addresses have been affected:
+  expect(await getAffectedAddressTxCountFromTxList(mysql, [txId2])).toStrictEqual({});
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1623,12 +1623,12 @@ test('rebuildAddressBalancesFromUtxos', async () => {
 
   const txHistory = [
     { address: addr1, txId, tokenId: token1, balance: 20, timestamp: timestamp1 },
-    { address: addr1, txId: txId4, tokenId: token1, balance: 21, timestamp: timestamp1 },
+    { address: addr1, txId: txId4, tokenId: token1, balance: 21, timestamp: timestamp1, voided: true },
 
     { address: addr2, txId, tokenId: token1, balance: 260, timestamp: timestamp1 },
     { address: addr2, txId, tokenId: token2, balance: 25, timestamp: timestamp1 },
     { address: addr2, txId: txId2, tokenId: token1, balance: 80, timestamp: timestamp1 },
-    { address: addr2, txId: txId3, tokenId: token1, balance: 15, timestamp: timestamp1 },
+    { address: addr2, txId: txId3, tokenId: token1, balance: 15, timestamp: timestamp1, voided: true },
   ];
 
   await addToAddressTxHistoryTable(mysql, txHistory);

--- a/tests/mempool.test.ts
+++ b/tests/mempool.test.ts
@@ -1,6 +1,8 @@
 import { onHandleOldVoidedTxs } from '@src/mempool';
 import { closeDbConnection, getDbConnection } from '@src/utils';
 import {
+  addToAddressTxHistoryTable,
+  addToAddressBalanceTable,
   addToTransactionTable,
   addToUtxoTable,
   checkUtxoTable,
@@ -39,6 +41,23 @@ test('onHandleOldVoidedTxs', async () => {
     [TX_IDS[2], 1, '00', ADDRESSES[3], 200, 0, null, null, false, null],
   ];
 
+  const txHistory = [
+    [ADDRESSES[0], TX_IDS[0], '00', 50, 10],
+    [ADDRESSES[1], TX_IDS[1], '00', 100, 10],
+    [ADDRESSES[2], TX_IDS[2], '00', 150, 10],
+    [ADDRESSES[3], TX_IDS[2], '00', 200, 10],
+  ];
+
+  const addressEntries = [
+    // address, tokenId, unlocked, locked, lockExpires, transactions, unlocked_authorities, locked_authorities
+    [ADDRESSES[0], '00', 0, 0, null, 1, 0, 0],
+    [ADDRESSES[1], '00', 0, 0, null, 1, 0, 0],
+    [ADDRESSES[2], '00', 0, 0, null, 1, 0, 0],
+    [ADDRESSES[3], '00', 0, 0, null, 1, 0, 0],
+  ];
+
+  await addToAddressBalanceTable(mysql, addressEntries);
+  await addToAddressTxHistoryTable(mysql, txHistory);
   await addToTransactionTable(mysql, transactions);
   await addToUtxoTable(mysql, utxos);
 

--- a/tests/mempool.test.ts
+++ b/tests/mempool.test.ts
@@ -42,10 +42,10 @@ test('onHandleOldVoidedTxs', async () => {
   ];
 
   const txHistory = [
-    [ADDRESSES[0], TX_IDS[0], '00', 50, 10],
-    [ADDRESSES[1], TX_IDS[1], '00', 100, 10],
-    [ADDRESSES[2], TX_IDS[2], '00', 150, 10],
-    [ADDRESSES[3], TX_IDS[2], '00', 200, 10],
+    { address: ADDRESSES[0], txId: TX_IDS[0], tokenId: '00', balance: 50, timestamp: 10 },
+    { address: ADDRESSES[1], txId: TX_IDS[1], tokenId: '00', balance: 100, timestamp: 10 },
+    { address: ADDRESSES[2], txId: TX_IDS[2], tokenId: '00', balance: 150, timestamp: 10 },
+    { address: ADDRESSES[3], txId: TX_IDS[2], tokenId: '00', balance: 200, timestamp: 10 },
   ];
 
   const addressEntries = [

--- a/tests/txProcessor.test.ts
+++ b/tests/txProcessor.test.ts
@@ -382,7 +382,7 @@ test('onHandleVoidedTxRequest', async () => {
   ]);
 
   await addToAddressBalanceTable(mysql, [
-    [addr, token, 2500, 0, null, 1, 0, 0],
+    [addr, token, 2500, 0, null, 2, 0, 0],
   ]);
 
   await addToAddressTxHistoryTable(mysql, [

--- a/tests/txProcessor.test.ts
+++ b/tests/txProcessor.test.ts
@@ -269,7 +269,7 @@ test('txProcessor should ignore NFT outputs', async () => {
   ]);
 
   await addToAddressTxHistoryTable(mysql, [
-    [addr, txId1, '00', 41, 0],
+    { address: addr, txId: txId1, tokenId: '00', balance: 41, timestamp: 0 },
   ]);
 
   await addToWalletBalanceTable(mysql, [{
@@ -386,7 +386,7 @@ test('onHandleVoidedTxRequest', async () => {
   ]);
 
   await addToAddressTxHistoryTable(mysql, [
-    [addr, txId1, token, 2500, 0],
+    { address: addr, txId: txId1, tokenId: token, balance: 2500, timestamp: 0 },
   ]);
 
   await addToWalletBalanceTable(mysql, [{

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -18,6 +18,15 @@ export interface WalletBalanceEntry {
   transactions: number;
 }
 
+export interface AddressTxHistoryTableEntry {
+  address: string;
+  txId: string;
+  tokenId: string;
+  balance: number;
+  timestamp: number;
+  voided?: boolean;
+}
+
 export interface AddressTableEntry {
   address: string;
   index: number;

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -8,7 +8,13 @@ import {
 } from '@src/types';
 import { getWalletId } from '@src/utils';
 import { walletUtils, network, HathorWalletServiceWallet } from '@hathor/wallet-lib';
-import { WalletBalanceEntry, AddressTableEntry, TokenTableEntry, WalletTableEntry } from '@tests/types';
+import {
+  AddressTxHistoryTableEntry,
+  AddressTableEntry,
+  WalletBalanceEntry,
+  WalletTableEntry,
+  TokenTableEntry,
+} from '@tests/types';
 import { RedisClient } from 'redis';
 import bitcore from 'bitcore-lib';
 
@@ -574,6 +580,27 @@ export const addToAddressTable = async (
   [payload]);
 };
 
+export const addToAddressTxHistoryTable = async (
+  mysql: ServerlessMysql,
+  entries: AddressTxHistoryTableEntry[],
+): Promise<void> => {
+  const payload = entries.map((entry) => ([
+    entry.address,
+    entry.txId,
+    entry.tokenId,
+    entry.balance,
+    entry.timestamp,
+    entry.voided || false,
+  ]));
+
+  await mysql.query(`
+    INSERT INTO \`address_tx_history\`(\`address\`, \`tx_id\`,
+                                       \`token_id\`, \`balance\`,
+                                       \`timestamp\`, \`voided\`)
+    VALUES ?`,
+  [payload]);
+};
+
 export const addToAddressBalanceTable = async (
   mysql: ServerlessMysql,
   entries: unknown[][],
@@ -583,18 +610,6 @@ export const addToAddressBalanceTable = async (
                                     \`unlocked_balance\`, \`locked_balance\`,
                                     \`timelock_expires\`, \`transactions\`,
                                     \`unlocked_authorities\`, \`locked_authorities\`)
-    VALUES ?`,
-  [entries]);
-};
-
-export const addToAddressTxHistoryTable = async (
-  mysql: ServerlessMysql,
-  entries: unknown[][],
-): Promise<void> => {
-  await mysql.query(`
-    INSERT INTO \`address_tx_history\`(\`address\`, \`tx_id\`,
-                                       \`token_id\`, \`balance\`,
-                                       \`timestamp\`)
     VALUES ?`,
   [entries]);
 };


### PR DESCRIPTION
This PR fixes https://github.com/HathorNetwork/hathor-explorer-service/issues/179


### Acceptance Criteria
- We should re-calculate the number of transactions properly on re-org by using the number of transactions that were affected by the re-org


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
