### PR TITLE
fix: explorer environment variable

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -37,16 +37,16 @@ custom:
       Set:
         custom.explorerServiceStage: dev
       ElseSet:
-        custom.explorerServiceStage: ${custom.stage}
+        custom.explorerServiceStage: ${self:custom.stage}
 
 plugins:
+  - serverless-plugin-ifelse # This must be the first plugin on this list to work properly
   - serverless-offline
   - serverless-webpack
   - serverless-prune-plugin
   - serverless-api-gateway-throttling
   - serverless-plugin-warmup
   - serverless-iam-roles-per-function
-  - serverless-plugin-ifelse
 
 
 resources:


### PR DESCRIPTION
The `v1.15.0` release had a minor bug that made the lambda invocations to `explorer-service` always point to the development environment. This PR fixes this with a correction on the `serverless.yml` configs.

### Acceptance Criteria
- Explorer Service `stage` environment variable must be correct on environments other than `dev`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
