### PR TITLE
fix: stop deleting address balance rows

### DIFF
--- a/src/commons.ts
+++ b/src/commons.ts
@@ -460,9 +460,6 @@ export const validateAddressBalances = async (mysql: ServerlessMysql, addresses:
   const addressBalances: AddressBalance[] = await fetchAddressBalance(mysql, addresses);
   const addressTxHistorySums: AddressTotalBalance[] = await fetchAddressTxHistorySum(mysql, addresses);
 
-  // if we have the full history of transactions, the number of rows must match:
-  assert.strictEqual(addressBalances.length, addressTxHistorySums.length);
-
   for (let i = 0; i < addressTxHistorySums.length; i++) {
     const addressBalance: AddressBalance = addressBalances[i];
     const addressTxHistorySum: AddressTotalBalance = addressTxHistorySums[i];

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2059,7 +2059,7 @@ export const rebuildAddressBalancesFromUtxos = async (
                 0,
                 BIT_OR(\`authorities\`), -- unlocked_authorities
                 0, -- locked_authorities
-                0, -- timelock_expires
+                NULL, -- timelock_expires
                 0 -- transactions
           FROM \`tx_output\`
          WHERE spent_by IS NULL

--- a/tests/txProcessor.test.ts
+++ b/tests/txProcessor.test.ts
@@ -517,7 +517,7 @@ test('onHandleVoidedTxRequest', async () => {
 
   // Balance should be back to 2500 as the transactions that spent the original utxo were voided and we should
   // have total of one transaction as both txId2 and txId3 were voided.
-  await expect(checkAddressBalanceTable(mysql, 1, addr, token, 2500, 0, 0, 1)).resolves.toBe(true);
+  await expect(checkAddressBalanceTable(mysql, 2, addr, token, 2500, 0, 0, 1)).resolves.toBe(true);
 }, 20000);
 
 test('txProcessor should rollback the entire transaction if an error occurs on balance calculation', async () => {

--- a/tests/txProcessor.test.ts
+++ b/tests/txProcessor.test.ts
@@ -517,7 +517,7 @@ test('onHandleVoidedTxRequest', async () => {
 
   // Balance should be back to 2500 as the transactions that spent the original utxo were voided and we should
   // have total of one transaction as both txId2 and txId3 were voided.
-  await expect(checkAddressBalanceTable(mysql, 2, addr, token, 2500, 0, 0, 1)).resolves.toBe(true);
+  await expect(checkAddressBalanceTable(mysql, 2, addr, token, 2500, 0, null, 1)).resolves.toBe(true);
 }, 20000);
 
 test('txProcessor should rollback the entire transaction if an error occurs on balance calculation', async () => {


### PR DESCRIPTION
## Motivation

[The queries we use to re-build](https://github.com/HathorNetwork/hathor-wallet-service/blob/9ba7f085fa50121d0912556f66237ece3f12ece9/src/db/index.ts#L2012) the `address_balance` table after a re-org or voided transaction are currently removing the affected rows

The problem with this approach is that if an address does not have at least one utxo, locked or unlocked, we would never add its row to the `address_balance` table again.

This is a problem for the new `big_addresses` feature that won't be able to display the `total_spent` and `total_received` information as it won't find the `address_balance` row for the addresses that are in this condition

An example is the `HCxPZcbWhiUT3zCx9rYbwGkQA1bzZKeEUe` address, that probably belongs to a pool that usually sends out every htr that it mines

Both queries for rebuilding the balances will return 0 results, causing it to never re-create the `address_balance` row.


### Acceptance Criteria
- When a re-org happens, we should not delete `address_balance` rows for affected addresses, instead we should set values to 0 (or NULL)


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
