### PR TITLE
chore: increase on new tx request timeout

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -132,6 +132,7 @@ functions:
         enabled: false
   onNewTxRequest:
     handler: src/txProcessor.onNewTxRequest
+    timeout: 12 # seconds
     warmup:
       walletWarmer:
         enabled: false


### PR DESCRIPTION
## Motivation
We are getting timeouts on the `onNewTxRequest` lambda for started wallets if they have a large amount of addresses

This is not a fix for the root cause of the issue but should allow us to get logs without the lambda timing out, so we can figure out what exactly is taking long to run

### Acceptance Criteria
- We should increase the `onNewTxRequest` to 12s


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
