### PR TITLE
feat: transactions count on token table

### DIFF
--- a/db/migrations/20220811192312-add-transaction-count-to-token.js
+++ b/db/migrations/20220811192312-add-transaction-count-to-token.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('token', 'transactions', {
+      type: Sequelize.INTEGER.UNSIGNED,
+      allowNull: false,
+      defaultValue: 0,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('token', 'transactions');
+  },
+};

--- a/db/migrations/20220811212756-add-hathor-to-token-table.js
+++ b/db/migrations/20220811212756-add-hathor-to-token-table.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('token', [{
+      id: '00',
+      name: 'Hathor',
+      symbol: 'HTR',
+      transactions: 0,
+    }]);
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.bulkDelete('token', [{
+      id: '00',
+      name: 'Hathor',
+      symbol: 'HTR',
+    }]);
+  },
+};

--- a/db/migrations/20220811222729-add-voided-index-to-address-tx-history.js
+++ b/db/migrations/20220811222729-add-voided-index-to-address-tx-history.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => queryInterface.addIndex(
+    'address_tx_history',
+    ['voided'], {
+      name: 'address_tx_history_voided_idx',
+      fields: 'voided',
+    },
+  ),
+  down: async (queryInterface) => queryInterface.removeIndex(
+    'address_tx_history',
+    'address_tx_history_voided_idx',
+  ),
+};

--- a/db/models/addresstxhistory.js
+++ b/db/models/addresstxhistory.js
@@ -56,6 +56,9 @@ module.exports = (sequelize, DataTypes) => {
     }, {
       name: 'address_tx_history_timestamp_idx',
       fields: ['timestamp'],
+    }, {
+      name: 'address_tx_history_voided_idx',
+      fields: ['voided'],
     }],
   });
   return AddressTxHistory;

--- a/db/models/token.js
+++ b/db/models/token.js
@@ -40,6 +40,10 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       defaultValue: DataTypes.literal('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'),
     },
+    transactions: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+    },
   }, {
     sequelize,
     modelName: 'Token',

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -191,6 +191,20 @@ export const getAddressBalanceMap = (
   return addressBalanceMap;
 };
 
+export const getTokenListFromInputsAndOutputs = (inputs: TxInput[], outputs: TxOutput[]): string[] => {
+  const tokenIds = new Set<string>([]);
+
+  for (const input of inputs) {
+    tokenIds.add(input.token);
+  }
+
+  for (const output of outputs) {
+    tokenIds.add(output.token);
+  }
+
+  return [...tokenIds];
+};
+
 /**
  * Get the map of token balances for each wallet.
  *

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -191,6 +191,13 @@ export const getAddressBalanceMap = (
   return addressBalanceMap;
 };
 
+/**
+ * Gets a list of tokens from a list of inputs and outputs
+ *
+ * @param inputs - The transaction inputs
+ * @param outputs - The transaction outputs
+ * @returns A list of tokens present in the inputs and outputs
+ */
 export const getTokenListFromInputsAndOutputs = (inputs: TxInput[], outputs: TxOutput[]): string[] => {
   const tokenIds = new Set<string>([]);
 

--- a/src/commons.ts
+++ b/src/commons.ts
@@ -198,7 +198,7 @@ export const getAddressBalanceMap = (
  * @param outputs - The transaction outputs
  * @returns A list of tokens present in the inputs and outputs
  */
-export const getTokenListFromInputsAndOutputs = (inputs: TxInput[], outputs: TxOutput[]): string[] => {
+export const getTokenListFromInputsAndOutputs = (inputs: TxInput[], outputs: TxOutputWithIndex[]): string[] => {
   const tokenIds = new Set<string>([]);
 
   for (const input of inputs) {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1255,7 +1255,6 @@ export const getWalletBalances = async (mysql: ServerlessMysql, walletId: string
     params.push(tokenIds);
   }
 
-  // use LEFT JOIN as HTR token ('00') won't be on the token table, so INNER JOIN would never match it
   const query = `
     SELECT NULL AS total_received,
            w.unlocked_balance AS unlocked_balance,
@@ -1268,8 +1267,7 @@ export const getWalletBalances = async (mysql: ServerlessMysql, walletId: string
            token.name AS name,
            token.symbol AS symbol
       FROM (${subquery}) w
- LEFT JOIN token
-        ON w.token_id = token.id
+INNER JOIN token ON w.token_id = token.id
   `;
 
   const results: DbSelectResult = await mysql.query(query, params);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2121,6 +2121,7 @@ export const rebuildAddressBalancesFromUtxos = async (
 
   const addressTransactionCount: StringMap<number> = await getAffectedAddressTxCountFromTxList(mysql, txList);
   const addressTotalReceived: StringMap<number> = await getAffectedAddressTotalReceivedFromTxList(mysql, txList);
+  const tokenTransactionCount: StringMap<number> = await getAffectedTokenTxCountFromTxList(mysql, txList);
 
   const finalValues = oldAddressTokenTransactions.map(({ address, tokenId, transactions, totalReceived }) => {
     const diffTransactions = addressTransactionCount[`${address}_${tokenId}`] || 0;
@@ -2140,6 +2141,15 @@ export const rebuildAddressBalancesFromUtxos = async (
        WHERE \`address\` = ?
          AND \`token_id\` = ?
     `, item);
+  }
+
+  // update token table with the correct amount of transactions
+  for (const token of Object.keys(tokenTransactionCount)) {
+    await mysql.query(`
+      UPDATE \`token\`
+        SET \`transactions\` = \`transactions\` - ?
+       WHERE \`id\` = ?
+    `, [tokenTransactionCount[token], token]);
   }
 };
 
@@ -2556,6 +2566,39 @@ export const getAffectedAddressTxCountFromTxList = async (
   }, {});
 
   return addressTransactions as StringMap<number>;
+};
+
+/**
+ * Get the number of affected transactions for each token from the address_tx_history table
+ * given a list of transactions
+ *
+ * @param mysql - Database connection
+ * @param txList - A list of affected transactions to get the token tx count
+
+ * @returns A Map with tokenId as key and the transaction count as values
+ */
+export const getAffectedTokenTxCountFromTxList = async (
+  mysql: ServerlessMysql,
+  txList: string[],
+): Promise<StringMap<number>> => {
+  const results: DbSelectResult = await mysql.query(`
+    SELECT token_id AS tokenId, COUNT(DISTINCT(tx_id)) AS txCount
+      FROM address_tx_history
+     WHERE tx_id IN (?)
+       AND voided = TRUE
+  GROUP BY token_id
+  `, [txList]);
+
+  const tokenTransactions = results.reduce((acc, result) => {
+    const tokenId = result.tokenId as string;
+    const txCount = result.txCount as number;
+
+    acc[tokenId] = txCount;
+
+    return acc;
+  }, {});
+
+  return tokenTransactions as StringMap<number>;
 };
 
 /**

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2572,9 +2572,10 @@ export const getAffectedAddressTotalReceivedFromTxList = async (
 ): Promise<StringMap<number>> => {
   const results: DbSelectResult = await mysql.query(`
     SELECT address, token_id as tokenId, SUM(value) as total
-     FROM tx_output
-     WHERE tx_id IN (?) AND voided = TRUE
-     GROUP BY address, token_id
+      FROM tx_output
+     WHERE tx_id IN (?)
+       AND voided = TRUE
+  GROUP BY address, token_id
   `, [txList]);
 
   const addressTotalReceivedMap = results.reduce((acc, result) => {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2590,7 +2590,13 @@ export const getAffectedAddressTotalReceivedFromTxList = async (
   return addressTotalReceivedMap as StringMap<number>;
 };
 
-export const updateTokensTxCount = async (
+/**
+ * Increment a list of tokens transactions count
+ *
+ * @param mysql - Database connection
+ * @param tokenList - The list of tokens to increment
+ */
+export const incrementTokensTxCount = async (
   mysql: ServerlessMysql,
   tokenList: string[],
 ): Promise<void> => {

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -16,6 +16,7 @@ import {
   unlockUtxos,
   unlockTimelockedUtxos,
   searchForLatestValidBlock,
+  getTokenListFromInputsAndOutputs,
   handleReorg,
   handleVoided,
   prepareOutputs,
@@ -34,6 +35,7 @@ import {
   storeTokenInformation,
   updateAddressTablesWithTx,
   updateWalletTablesWithTx,
+  updateTokensTxCount,
   fetchTx,
   addMiner,
 } from '@src/db';
@@ -376,6 +378,11 @@ const _unsafeAddNewTx = async (_logger: Logger, tx: Transaction, now: number, bl
   logger.debug('Updating address_balance and address_tx_history tables', {
     addressBalanceMap,
   });
+
+  const tokenList: string[] = getTokenListFromInputsAndOutputs(tx.inputs, outputs);
+
+  // Update transaction count with the new tx
+  await updateTokensTxCount(mysql, tokenList);
 
   // update address tables (address, address_balance, address_tx_history)
   await updateAddressTablesWithTx(mysql, txId, tx.timestamp, addressBalanceMap);

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -35,7 +35,7 @@ import {
   storeTokenInformation,
   updateAddressTablesWithTx,
   updateWalletTablesWithTx,
-  updateTokensTxCount,
+  incrementTokensTxCount,
   fetchTx,
   addMiner,
 } from '@src/db';
@@ -382,7 +382,7 @@ const _unsafeAddNewTx = async (_logger: Logger, tx: Transaction, now: number, bl
   const tokenList: string[] = getTokenListFromInputsAndOutputs(tx.inputs, outputs);
 
   // Update transaction count with the new tx
-  await updateTokensTxCount(mysql, tokenList);
+  await incrementTokensTxCount(mysql, tokenList);
 
   // update address tables (address, address_balance, address_tx_history)
   await updateAddressTablesWithTx(mysql, txId, tx.timestamp, addressBalanceMap);

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,10 +102,13 @@ export class TokenInfo {
 
   symbol: string;
 
-  constructor(id: string, name: string, symbol: string) {
+  transactions: number;
+
+  constructor(id: string, name: string, symbol: string, transactions?: number) {
     this.id = id;
     this.name = name;
     this.symbol = symbol;
+    this.transactions = transactions || 0;
 
     const hathorConfig = hathorLib.constants.HATHOR_TOKEN_CONFIG;
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -261,12 +261,15 @@ test('GET /balances', async () => {
     readyAt: 10001,
   }]);
 
+  // add the hathor token as it will be deleted by the beforeAll
+  const htrToken = { id: '00', name: 'Hathor', symbol: 'HTR' };
   // add tokens
   const token1 = { id: 'token1', name: 'MyToken1', symbol: 'MT1' };
   const token2 = { id: 'token2', name: 'MyToken2', symbol: 'MT2' };
   const token3 = { id: 'token3', name: 'MyToken3', symbol: 'MT3' };
   const token4 = { id: 'token4', name: 'MyToken4', symbol: 'MT4' };
   await addToTokenTable(mysql, [
+    { ...htrToken, transactions: 0 },
     { id: token1.id, name: token1.name, symbol: token1.symbol, transactions: 0 },
     { id: token2.id, name: token2.name, symbol: token2.symbol, transactions: 0 },
     { id: token3.id, name: token3.name, symbol: token3.symbol, transactions: 0 },

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -267,10 +267,10 @@ test('GET /balances', async () => {
   const token3 = { id: 'token3', name: 'MyToken3', symbol: 'MT3' };
   const token4 = { id: 'token4', name: 'MyToken4', symbol: 'MT4' };
   await addToTokenTable(mysql, [
-    { id: token1.id, name: token1.name, symbol: token1.symbol },
-    { id: token2.id, name: token2.name, symbol: token2.symbol },
-    { id: token3.id, name: token3.name, symbol: token3.symbol },
-    { id: token4.id, name: token4.name, symbol: token4.symbol },
+    { id: token1.id, name: token1.name, symbol: token1.symbol, transactions: 0 },
+    { id: token2.id, name: token2.name, symbol: token2.symbol, transactions: 0 },
+    { id: token3.id, name: token3.name, symbol: token3.symbol, transactions: 0 },
+    { id: token4.id, name: token4.name, symbol: token4.symbol, transactions: 0 },
   ]);
 
   // missing wallet
@@ -1249,8 +1249,8 @@ test('GET /wallet/tokens/token_id/details', async () => {
   const token2 = { id: 'token2', name: 'MyToken2', symbol: 'MT2' };
 
   await addToTokenTable(mysql, [
-    { id: token1.id, name: token1.name, symbol: token1.symbol },
-    { id: token2.id, name: token2.name, symbol: token2.symbol },
+    { id: token1.id, name: token1.name, symbol: token1.symbol, transactions: 0 },
+    { id: token2.id, name: token2.name, symbol: token2.symbol, transactions: 0 },
   ]);
 
   await addToUtxoTable(mysql, [

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1635,6 +1635,13 @@ test('rebuildAddressBalancesFromUtxos', async () => {
 
   await addToAddressTxHistoryTable(mysql, txHistory);
 
+  // add to the token table
+  await addToTokenTable(mysql, [
+    { id: token1, name: 'token1', symbol: 'TKN1', transactions: 2 },
+  ]);
+
+  await expect(checkTokenTable(mysql, 1, token1, 'TKN1', 'token1', 2)).resolves.toBe(true);
+
   // We are only using the txList parameter on `transactions` recalculation, so our balance
   // checks should include txId3 and txId4, but the transaction count should not.
   await rebuildAddressBalancesFromUtxos(mysql, [addr1, addr2], [txId3, txId4]);
@@ -1657,6 +1664,8 @@ test('rebuildAddressBalancesFromUtxos', async () => {
   expect(addressBalances[2].address).toStrictEqual(addr2);
   expect(addressBalances[2].transactions).toStrictEqual(1);
   expect(addressBalances[2].tokenId).toStrictEqual('token2');
+
+  await expect(checkTokenTable(mysql, 1, token1, 'TKN1', 'token1', 0)).resolves.toBe(true);
 });
 
 test('markAddressTxHistoryAsVoided', async () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1640,7 +1640,12 @@ test('rebuildAddressBalancesFromUtxos', async () => {
     { id: token1, name: 'token1', symbol: 'TKN1', transactions: 2 },
   ]);
 
-  await expect(checkTokenTable(mysql, 1, token1, 'TKN1', 'token1', 2)).resolves.toBe(true);
+  await expect(checkTokenTable(mysql, 1, [{
+    tokenId: token1,
+    tokenSymbol: 'TKN1',
+    tokenName: 'token1',
+    transactions: 2,
+  }])).resolves.toBe(true);
 
   // We are only using the txList parameter on `transactions` recalculation, so our balance
   // checks should include txId3 and txId4, but the transaction count should not.
@@ -1665,7 +1670,12 @@ test('rebuildAddressBalancesFromUtxos', async () => {
   expect(addressBalances[2].transactions).toStrictEqual(1);
   expect(addressBalances[2].tokenId).toStrictEqual('token2');
 
-  await expect(checkTokenTable(mysql, 1, token1, 'TKN1', 'token1', 0)).resolves.toBe(true);
+  await expect(checkTokenTable(mysql, 1, [{
+    tokenId: token1,
+    tokenSymbol: 'TKN1',
+    tokenName: 'token1',
+    transactions: 0,
+  }])).resolves.toBe(true);
 });
 
 test('markAddressTxHistoryAsVoided', async () => {
@@ -2148,7 +2158,20 @@ test('incrementTokensTxCount', async () => {
 
   await incrementTokensTxCount(mysql, ['token1', '00', 'token2']);
 
-  await expect(checkTokenTable(mysql, 3, token1.id, token1.symbol, token1.name, token1.transactions + 1)).resolves.toBe(true);
-  await expect(checkTokenTable(mysql, 3, token2.id, token2.symbol, token2.name, token2.transactions + 1)).resolves.toBe(true);
-  await expect(checkTokenTable(mysql, 3, htr.id, htr.symbol, htr.name, htr.transactions + 1)).resolves.toBe(true);
+  await expect(checkTokenTable(mysql, 3, [{
+    tokenId: token1.id,
+    tokenSymbol: token1.symbol,
+    tokenName: token1.name,
+    transactions: token1.transactions + 1,
+  }, {
+    tokenId: token2.id,
+    tokenSymbol: token2.symbol,
+    tokenName: token2.name,
+    transactions: token2.transactions + 1,
+  }, {
+    tokenId: htr.id,
+    tokenSymbol: htr.symbol,
+    tokenName: htr.name,
+    transactions: htr.transactions + 1,
+  }])).resolves.toBe(true);
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -2136,16 +2136,19 @@ test('getAffectedAddressTxCountFromTxList', async () => {
 test('incrementTokensTxCount', async () => {
   expect.hasAssertions();
 
+  const htr = new TokenInfo('00', 'Hathor', 'HTR', 5);
   const token1 = new TokenInfo('token1', 'MyToken1', 'MT1', 10);
   const token2 = new TokenInfo('token2', 'MyToken2', 'MT2', 15);
 
   await addToTokenTable(mysql, [
+    { id: htr.id, name: htr.name, symbol: htr.symbol, transactions: htr.transactions },
     { id: token1.id, name: token1.name, symbol: token1.symbol, transactions: token1.transactions },
     { id: token2.id, name: token2.name, symbol: token2.symbol, transactions: token2.transactions },
   ]);
 
   await incrementTokensTxCount(mysql, ['token1', '00', 'token2']);
 
-  await expect(checkTokenTable(mysql, 2, token1.id, token1.symbol, token1.name, token1.transactions + 1)).resolves.toBe(true);
-  await expect(checkTokenTable(mysql, 2, token1.id, token1.symbol, token1.name, token1.transactions + 1)).resolves.toBe(true);
+  await expect(checkTokenTable(mysql, 3, token1.id, token1.symbol, token1.name, token1.transactions + 1)).resolves.toBe(true);
+  await expect(checkTokenTable(mysql, 3, token2.id, token2.symbol, token2.name, token2.transactions + 1)).resolves.toBe(true);
+  await expect(checkTokenTable(mysql, 3, htr.id, htr.symbol, htr.name, htr.transactions + 1)).resolves.toBe(true);
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -63,7 +63,7 @@ import {
   getTotalTransactions,
   getAvailableAuthorities,
   getAffectedAddressTxCountFromTxList,
-  updateTokensTxCount,
+  incrementTokensTxCount,
 } from '@src/db';
 import {
   beginTransaction,
@@ -2124,7 +2124,7 @@ test('getAffectedAddressTxCountFromTxList', async () => {
   expect(await getAffectedAddressTxCountFromTxList(mysql, [txId2])).toStrictEqual({});
 });
 
-test('updateTokensTxCount', async () => {
+test('incrementTokensTxCount', async () => {
   expect.hasAssertions();
 
   const token1 = new TokenInfo('token1', 'MyToken1', 'MT1', 10);
@@ -2135,7 +2135,7 @@ test('updateTokensTxCount', async () => {
     { id: token2.id, name: token2.name, symbol: token2.symbol, transactions: token2.transactions },
   ]);
 
-  await updateTokensTxCount(mysql, ['token1', '00', 'token2']);
+  await incrementTokensTxCount(mysql, ['token1', '00', 'token2']);
 
   await expect(checkTokenTable(mysql, 2, token1.id, token1.symbol, token1.name, token1.transactions + 1)).resolves.toBe(true);
   await expect(checkTokenTable(mysql, 2, token1.id, token1.symbol, token1.name, token1.transactions + 1)).resolves.toBe(true);

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -38,6 +38,7 @@ export interface TokenTableEntry {
   id: string;
   name: string;
   symbol: string;
+  transactions: number;
 }
 
 export interface WalletTableEntry {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyEvent } from 'aws-lambda';
 import { ServerlessMysql } from 'serverless-mysql';
+import { isEqual } from 'lodash';
 import {
   DbSelectResult,
   TxInput,
@@ -458,13 +459,17 @@ export const checkWalletBalanceTable = async (
   return true;
 };
 
+type Token = {
+  tokenId: string;
+  tokenSymbol: string;
+  tokenName: string;
+  transactions: number;
+}
+
 export const checkTokenTable = async (
   mysql: ServerlessMysql,
   totalResults: number,
-  tokenId: string,
-  tokenSymbol: string,
-  tokenName: string,
-  transactions: number,
+  entries: Token[],
 ): Promise<boolean | Record<string, unknown>> => {
   // first check the total number of rows in the table
   let results: DbSelectResult = await mysql.query('SELECT * FROM `token`');
@@ -479,25 +484,41 @@ export const checkTokenTable = async (
 
   if (totalResults === 0) return true;
 
-  // now fetch the exact entry
+  // Fetch the exact entries
   const query = `
-    SELECT *
+    SELECT id AS tokenId,
+           symbol AS tokenSymbol,
+           name AS tokenName,
+           transactions
       FROM \`token\`
-     WHERE \`id\` = ?
-       AND \`name\` = ?
-       AND \`symbol\` = ?
-       AND \`transactions\` = ?
+     WHERE \`id\` IN (?)
   `;
   results = await mysql.query(
     query,
-    [tokenId, tokenName, tokenSymbol, transactions],
+    [entries.map((token) => token.tokenId)],
   );
 
-  if (results.length !== 1) {
+  const invalidResults = results.filter((token: Token) => {
+    const entry = entries.find(({ tokenId }) => tokenId === token.tokenId);
+
+    if (!entry) {
+      return true;
+    }
+
+    // token is a RowDataPacket, so just cast it to an object so we can
+    // compare it
+    if (!isEqual({ ...token }, entry)) {
+      return true;
+    }
+
+    return false;
+  });
+
+  if (invalidResults.length > 0) {
     return {
-      error: 'checkAddressTable query',
-      params: { tokenId, tokenName, tokenSymbol, transactions },
-      results,
+      error: 'checkTokenTable query',
+      params: entries,
+      invalidResults,
     };
   }
   return true;


### PR DESCRIPTION
### Motivation

We have a feature on the explorer that displays the total number of transactions for a given token.

Currently, we are using the transactions column from the `address_balance` table to display it, by summing all values for a given `token_id`

The problem with this approach is that there are transactions with more than one address, so the final count of transactions will have duplicate transactions being counted

The idea here is to start counting the number of transactions on the `onNewTxRequest` lambda for each token and also fixing the column after a re-org or voided tx happens

### Acceptance Criteria
- We should add a counter to the `token` table to sum the number of transactions for each row
- We should handle re-orgs and voided transactions properly, reducing from this number of transactions the number of transactions voided


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
