### PR TITLE
chore: added coverage upload and codecov

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,6 +2,7 @@ name: PR Validation
 on:
   pull_request:
     types: [ready_for_review, synchronize]
+    branches: [master, dev]
     paths-ignore:
       - '**.md'
   push:
@@ -80,3 +81,7 @@ jobs:
           WS_DOMAIN: ws.ci.wallet-service.hathor.network
           EXPLORER_SERVICE_LAMBDA_ENDPOINT: https://lambda.eu-central-1.amazonaws.com
           WALLET_SERVICE_LAMBDA_ENDPOINT: https://lambda.eu-central-1.amazonaws.com
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+        with:
+          verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  branch: 
+
+coverage:
+  status:
+    project:
+      default:
+        # minimum coverage ratio that the commit must meet to be considered a success
+        target: 88%
+        if_ci_failed: error
+        only_pulls: true
+    patch:
+      default:
+        # minimum coverage ratio that the commit must meet to be considered a success
+        target: 88%
+        if_ci_failed: error
+        only_pulls: true
+
+github_checks:
+  annotations: true


### PR DESCRIPTION
### Acceptance Criteria
- We should upload code coverage on the PR-validation CI action
- This repo should get a codecov report posted by the codecov bot


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
