### PR TITLE
chore: exit if migration fails

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -101,6 +101,10 @@ phases:
           done
 
           make migrate;
+          if [ $? -ne 0 ]; then
+            echo "Dev migration failed"
+            exit 1
+          fi
           make deploy-lambdas-dev-testnet;
         fi
       - |
@@ -111,6 +115,10 @@ phases:
           done
 
           make migrate;
+          if [ $? -ne 0 ]; then
+            echo "Testnet migration failed"
+            exit 1
+          fi
           make deploy-lambdas-testnet;
         fi
       - |
@@ -121,6 +129,10 @@ phases:
           done
 
           make migrate;
+          if [ $? -ne 0 ]; then
+            echo "Mainnet migration failed"
+            exit 1
+          fi
           make deploy-lambdas-mainnet;
         fi
 

--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -94,8 +94,8 @@ phases:
   build:
     commands:
       - |
+        set -e;
         if expr "${GIT_REF_TO_DEPLOY}" : "dev" >/dev/null; then
-          set -e;
           # Gets all env vars with `dev_` prefix and re-exports them without the prefix
           for var in "${!dev_@}"; do
             export ${var#dev_}=${!var}
@@ -103,10 +103,9 @@ phases:
 
           make migrate;
           make deploy-lambdas-dev-testnet;
-        fi
-      - |
+        fi;
+
         if expr "${GIT_REF_TO_DEPLOY}" : "master" >/dev/null; then
-          set -e;
           # Gets all env vars with `testnet_` prefix and re-exports them without the prefix
           for var in "${!testnet_@}"; do
             export ${var#testnet_}=${!var}
@@ -114,10 +113,9 @@ phases:
 
           make migrate;
           make deploy-lambdas-testnet;
-        fi
-      - |
+        fi;
+
         if expr "${GIT_REF_TO_DEPLOY}" : "v.*" >/dev/null; then
-          set -e;
           # Gets all env vars with `mainnet_` prefix and re-exports them without the prefix
           for var in "${!mainnet_@}"; do
             export ${var#mainnet_}=${!var}
@@ -125,5 +123,4 @@ phases:
 
           make migrate;
           make deploy-lambdas-mainnet;
-        fi
-
+        fi;

--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -95,44 +95,35 @@ phases:
     commands:
       - |
         if expr "${GIT_REF_TO_DEPLOY}" : "dev" >/dev/null; then
+          set -e;
           # Gets all env vars with `dev_` prefix and re-exports them without the prefix
           for var in "${!dev_@}"; do
             export ${var#dev_}=${!var}
           done
 
           make migrate;
-          if [ $? -ne 0 ]; then
-            echo "Dev migration failed"
-            exit 1
-          fi
           make deploy-lambdas-dev-testnet;
         fi
       - |
         if expr "${GIT_REF_TO_DEPLOY}" : "master" >/dev/null; then
+          set -e;
           # Gets all env vars with `testnet_` prefix and re-exports them without the prefix
           for var in "${!testnet_@}"; do
             export ${var#testnet_}=${!var}
           done
 
           make migrate;
-          if [ $? -ne 0 ]; then
-            echo "Testnet migration failed"
-            exit 1
-          fi
           make deploy-lambdas-testnet;
         fi
       - |
         if expr "${GIT_REF_TO_DEPLOY}" : "v.*" >/dev/null; then
+          set -e;
           # Gets all env vars with `mainnet_` prefix and re-exports them without the prefix
           for var in "${!mainnet_@}"; do
             export ${var#mainnet_}=${!var}
           done
 
           make migrate;
-          if [ $? -ne 0 ]; then
-            echo "Mainnet migration failed"
-            exit 1
-          fi
           make deploy-lambdas-mainnet;
         fi
 


### PR DESCRIPTION
### Acceptance Criteria
- We should make sure that if the migration fails the build will fail without deploying the lambdas


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
