### PR TITLE
chore: remove enable-only-new-tx column from push_devices table

### DIFF
--- a/db/migrations/20221114185330-remove-enable-only-new-tx-conlumn.js
+++ b/db/migrations/20221114185330-remove-enable-only-new-tx-conlumn.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    queryInterface.removeColumn('push_devices', 'enable_only_new_tx');
+  },
+
+  async down(queryInterface, Sequelize) {
+    queryInterface.addColumn('push_devices', 'enable_only_new_tx', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+};

--- a/db/models/pushdevices.js
+++ b/db/models/pushdevices.js
@@ -41,11 +41,6 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: false,
         defaultValue: false,
       },
-      enable_only_new_tx: {
-        type: DataTypes.BOOLEAN,
-        allowNull: false,
-        defaultValue: false,
-      },
       updated_at: {
         type: 'TIMESTAMP',
         allowNull: false,


### PR DESCRIPTION
### Acceptance Criteria
- remove enable_only_new_tx column from push_devices table


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
