### PR TITLE
chore: increased loadTokensAsync to 5 minutes (up from 6s)

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -220,6 +220,7 @@ functions:
           arn:aws:lambda:eu-central-1:769498303037:function:hathor-explorer-service-${self:custom.explorerServiceStage}-create_or_update_dag_metadata
   loadWalletAsync:
     handler: src/api/wallet.loadWallet
+    timeout: 300 # 5 minutes
     warmup:
       walletWarmer:
         enabled: false


### PR DESCRIPTION
### Acceptance Criteria
- `loadTokensAsync` should not timeout on larger wallets during the load process


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
