### PR TITLE
fix: pushRegister and pushUpdate

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -463,7 +463,7 @@ functions:
     handler: src/api/pushRegister.register
     events:
       - http:
-          path: push/register
+          path: wallet/push/register
           method: post
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
@@ -474,7 +474,7 @@ functions:
     handler: src/api/pushUpdate.update
     events:
       - http:
-          path: push/update
+          path: wallet/push/update
           method: put
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
@@ -485,7 +485,7 @@ functions:
     handler: src/api/pushUnregister.unregister
     events:
       - http:
-          path: push/unregister/{deviceId}
+          path: wallet/push/unregister/{deviceId}
           method: delete
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}

--- a/src/api/pushRegister.ts
+++ b/src/api/pushRegister.ts
@@ -40,7 +40,15 @@ class PushRegisterInputValidator {
  * This lambda is called by API Gateway on POST /push/register
  */
 export const register: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId, event) => {
-  const { value: body, error } = PushRegisterInputValidator.validate(event.body);
+  const eventBody = (function parseBody(body) {
+    try {
+      return JSON.parse(body);
+    } catch (e) {
+      return null;
+    }
+  }(event.body));
+
+  const { value: body, error } = PushRegisterInputValidator.validate(eventBody);
 
   if (error) {
     const details = error.details.map((err) => ({

--- a/src/api/pushUpdate.ts
+++ b/src/api/pushUpdate.ts
@@ -39,7 +39,15 @@ class PushUpdateInputValidator {
  * This lambda is called by API Gateway on POST /push/register
  */
 export const update: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (walletId, event) => {
-  const { value: body, error } = PushUpdateInputValidator.validate(event.body);
+  const eventBody = (function parseBody(body) {
+    try {
+      return JSON.parse(body);
+    } catch (e) {
+      return null;
+    }
+  }(event.body));
+
+  const { value: body, error } = PushUpdateInputValidator.validate(eventBody);
 
   if (error) {
     const details = error.details.map((err) => ({


### PR DESCRIPTION
### Acceptance Criteria
- Add JSON parser to event.body on pushRegister and pushUpdate lambdas, because API Gateway stringfy the payload
- Add wallet/ path as prefix for push/ paths, because auth guard has the policy to allow only wallet/ and tx/ paths

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
