### PR TITLE
fix: stringify event.body to call pushRegister and pushUpdate

### DIFF
--- a/tests/pushRegister.test.ts
+++ b/tests/pushRegister.test.ts
@@ -34,12 +34,12 @@ test('register a device for push notification', async () => {
     readyAt: 10001,
   }]);
 
-  const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+  const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
     deviceId: 'device1',
     pushProvider: 'android',
     enablePush: true,
     enableShowAmounts: false,
-  });
+  }));
 
   const result = await register(event, null, null) as APIGatewayProxyResult;
   const returnBody = JSON.parse(result.body as string);
@@ -62,11 +62,11 @@ describe('statusCode:200', () => {
       readyAt: 10001,
     }]);
 
-    const payloadWithoutEnablePush = {
+    const payloadWithoutEnablePush = JSON.stringify({
       deviceId: 'device1',
       pushProvider: 'android',
       enableShowAmounts: false,
-    };
+    });
     const event = makeGatewayEventWithAuthorizer('my-wallet', null, payloadWithoutEnablePush);
 
     const result = await register(event, null, null) as APIGatewayProxyResult;
@@ -98,11 +98,11 @@ describe('statusCode:200', () => {
       readyAt: 10001,
     }]);
 
-    const payloadWithoutEnableShowAmounts = {
+    const payloadWithoutEnableShowAmounts = JSON.stringify({
       deviceId: 'device1',
       pushProvider: 'android',
       enablePush: true,
-    };
+    });
     const event = makeGatewayEventWithAuthorizer('my-wallet', null, payloadWithoutEnableShowAmounts);
 
     const result = await register(event, null, null) as APIGatewayProxyResult;
@@ -134,12 +134,12 @@ describe('statusCode:200', () => {
       readyAt: 10001,
     }]);
 
-    const payload = {
+    const payload = JSON.stringify({
       deviceId: 'device1',
       pushProvider: 'android',
       enablePush: true,
       enableShowAmounts: false,
-    };
+    });
     const event = makeGatewayEventWithAuthorizer('my-wallet', null, payload);
 
     let result = await register(event, null, null) as APIGatewayProxyResult;
@@ -171,12 +171,12 @@ describe('statusCode:400', () => {
       readyAt: 10001,
     }]);
 
-    const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+    const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
       deviceId: 'device1',
       pushProvider,
       enablePush: true,
       enableShowAmounts: false,
-    });
+    }));
 
     const result = await register(event, null, null) as APIGatewayProxyResult;
     const returnBody = JSON.parse(result.body as string);
@@ -210,12 +210,12 @@ Array [
       readyAt: 10001,
     }]);
 
-    const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+    const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
       deviceId,
       pushProvider: 'android',
       enablePush: true,
       enableShowAmounts: false,
-    });
+    }));
 
     const result = await register(event, null, null) as APIGatewayProxyResult;
     const returnBody = JSON.parse(result.body as string);
@@ -240,12 +240,12 @@ describe('statusCode:404', () => {
   it('should validate wallet existence', async () => {
     expect.hasAssertions();
 
-    const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+    const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
       deviceId: 'device1',
       pushProvider: 'android',
       enablePush: true,
       enableShowAmounts: false,
-    });
+    }));
 
     const result = await register(event, null, null) as APIGatewayProxyResult;
     const returnBody = JSON.parse(result.body as string);

--- a/tests/pushSendNotificationToDevice.test.ts
+++ b/tests/pushSendNotificationToDevice.test.ts
@@ -51,12 +51,12 @@ test('send push notification to the right provider', async () => {
     readyAt: 10001,
   }]);
 
-  const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+  const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
     deviceId: 'device1',
     pushProvider: 'android',
     enablePush: true,
     enableShowAmounts: false,
-  });
+  }));
   await register(event, null, null) as APIGatewayProxyResult;
 
   const validPayload = {
@@ -93,12 +93,12 @@ test('should unregister device when invalid device id', async () => {
     readyAt: 10001,
   }]);
 
-  const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+  const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
     deviceId: 'device1',
     pushProvider: 'android',
     enablePush: true,
     enableShowAmounts: false,
-  });
+  }));
   await register(event, null, null) as APIGatewayProxyResult;
   await expect(
     checkPushDevicesTable(mysql, 1),
@@ -195,12 +195,12 @@ describe('validation', () => {
       readyAt: 10001,
     }]);
 
-    const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+    const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
       deviceId: 'device1',
       pushProvider: 'android',
       enablePush: true,
       enableShowAmounts: false,
-    });
+    }));
     await register(event, null, null) as APIGatewayProxyResult;
 
     const payloadWithoutMetadata = {
@@ -252,12 +252,12 @@ describe('alert', () => {
       readyAt: 10001,
     }]);
 
-    const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+    const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
       deviceId: 'device1',
       pushProvider: 'ios',
       enablePush: true,
       enableShowAmounts: false,
-    });
+    }));
     await register(event, null, null) as APIGatewayProxyResult;
 
     const validPayload = {

--- a/tests/pushUpdate.test.ts
+++ b/tests/pushUpdate.test.ts
@@ -50,11 +50,11 @@ test('update push device given a wallet', async () => {
     enableShowAmounts,
   });
 
-  const event = makeGatewayEventWithAuthorizer(walletId, null, {
+  const event = makeGatewayEventWithAuthorizer(walletId, null, JSON.stringify({
     deviceId,
     enablePush: true, // enables push notification
     enableShowAmounts: false,
-  });
+  }));
 
   const result = await update(event, null, null) as APIGatewayProxyResult;
   const returnBody = JSON.parse(result.body as string);
@@ -101,10 +101,10 @@ describe('statusCode:200', () => {
     });
 
     // enablePush should be disabled by default
-    const event = makeGatewayEventWithAuthorizer(walletId, null, {
+    const event = makeGatewayEventWithAuthorizer(walletId, null, JSON.stringify({
       deviceId,
       enableShowAmounts: false,
-    });
+    }));
 
     const result = await update(event, null, null) as APIGatewayProxyResult;
     const returnBody = JSON.parse(result.body as string);
@@ -150,10 +150,10 @@ describe('statusCode:200', () => {
     });
 
     // enableShowAmounts should be disabled by default
-    const event = makeGatewayEventWithAuthorizer(walletId, null, {
+    const event = makeGatewayEventWithAuthorizer(walletId, null, JSON.stringify({
       deviceId,
       enablePush,
-    });
+    }));
 
     const result = await update(event, null, null) as APIGatewayProxyResult;
     const returnBody = JSON.parse(result.body as string);
@@ -186,11 +186,11 @@ describe('statusCode:400', () => {
       readyAt: 10001,
     }]);
 
-    const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+    const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
       deviceId,
       enablePush: false,
       enableShowAmounts: false,
-    });
+    }));
 
     const result = await update(event, null, null) as APIGatewayProxyResult;
     const returnBody = JSON.parse(result.body as string);
@@ -226,11 +226,11 @@ describe('statusCode:404', () => {
       readyAt: 10001,
     }]);
 
-    const event = makeGatewayEventWithAuthorizer('my-wallet', null, {
+    const event = makeGatewayEventWithAuthorizer('my-wallet', null, JSON.stringify({
       deviceId,
       enablePush: false,
       enableShowAmounts: false,
-    });
+    }));
 
     const result = await update(event, null, null) as APIGatewayProxyResult;
     const returnBody = JSON.parse(result.body as string);


### PR DESCRIPTION
### Acceptance Criteria
- stringify event.body to call pushRegister and pushUpdate on tests
- Cloud Gateway stringify the request payload

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
