### PR TITLE
fix: import default fcmAdmin to invoke initializeApp

### DIFF
--- a/src/utils/pushnotification.utils.ts
+++ b/src/utils/pushnotification.utils.ts
@@ -1,6 +1,6 @@
 import { Lambda } from 'aws-sdk';
 import { SendNotificationToDevice, StringMap, WalletBalanceValue } from '@src/types';
-import { credential, initializeApp, messaging, ServiceAccount } from 'firebase-admin';
+import fcmAdmin, { credential, messaging, ServiceAccount } from 'firebase-admin';
 import { MulticastMessage } from 'firebase-admin/messaging';
 import createDefaultLogger from '@src/logger';
 
@@ -87,7 +87,7 @@ const serviceAccount = {
   client_x509_cert_url: FIREBASE_CLIENT_X509_CERT_URL,
 };
 
-initializeApp({
+fcmAdmin.initializeApp({
   credential: credential.cert(serviceAccount as ServiceAccount),
   projectId: FIREBASE_PROJECT_ID,
 });

--- a/tests/utils/pushnotification.utils.boundary.test.ts
+++ b/tests/utils/pushnotification.utils.boundary.test.ts
@@ -2,18 +2,17 @@
 import { PushNotificationUtils } from '@src/utils/pushnotification.utils';
 import { SendNotificationToDevice } from '@src/types';
 
-const registrationToken = 'fGw0qy4TGgk:APA91bGtWGjuhp4WRhHXgbabIYp1jxEKI08ofj_v1bKhWAGJQ4e3arRCW'
-  + 'zeTfHaLz83mBnDh0aPWB1AykXAVUUGl2h1wT4XI6XazWpvY7RBUSYfoxtqSWGIm2nvWh2BOP1YG501SsRoE';
+const registrationToken = 'fR4TqxCASDCtV1sWs53ZO0:APA91bE0lw-t44auU5AS0-cj3qcUiIH_bGY8m_TwnNvnx5xEus3yPYy-95zmz-h6PNp9tKFazyfu0wb7E0o_zqjR3eqP3Q1lSMbgK9X6NQIUAhkLtAmDE1LaEoN7ql1p18XPHQClM5P0';
 const invalidRegistrationToken = 'invalid-registration-token';
 
 // This test was designed to make real call to FCM.
 // NOTE: Use a testing project. Do not use production project.
 describe('pushnotification.utils', () => {
   describe('sendToFcm', () => {
-    it.skip('should call FCM', async () => {
+    it('should call FCM', async () => {
       expect.hasAssertions();
 
-      const deviceId = invalidRegistrationToken;
+      const deviceId = registrationToken;
       const title = 'New transaction';
       const description = 'You have received 1 XYZ';
       const txId = 'tx1';


### PR DESCRIPTION
### Acceptance Criteria
- import default fcmAdmin to invoke initializeApp. By importing initializeApp direct, it lacks the fcm internal context

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
