### PR TITLE
fix: codebuild was failing when trying to set an env var with newlines

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -125,7 +125,7 @@ phases:
         if expr "${GIT_REF_TO_DEPLOY}" : "dev" >/dev/null; then
           # Gets all env vars with `dev_` prefix and re-exports them without the prefix
           for var in "${!dev_@}"; do
-            export ${var#dev_}=${!var}
+            export ${var#dev_}="${!var}"
           done
 
           make migrate;
@@ -135,7 +135,7 @@ phases:
         if expr "${GIT_REF_TO_DEPLOY}" : "master" >/dev/null; then
           # Gets all env vars with `testnet_` prefix and re-exports them without the prefix
           for var in "${!testnet_@}"; do
-            export ${var#testnet_}=${!var}
+            export ${var#testnet_}="${!var}"
           done
 
           make migrate;
@@ -145,7 +145,7 @@ phases:
         if expr "${GIT_REF_TO_DEPLOY}" : "v.*" >/dev/null; then
           # Gets all env vars with `mainnet_` prefix and re-exports them without the prefix
           for var in "${!mainnet_@}"; do
-            export ${var#mainnet_}=${!var}
+            export ${var#mainnet_}="${!var}"
           done
 
           make migrate;


### PR DESCRIPTION
### Acceptance Criteria
Codebuild was failing when trying to set an env var with newlines.

This is a script that demonstrates the problem:

```bash
set -e;

export dev_TEST="VALUE WITH 	TABS\nAND NEWLINE"

for var in "${!dev_@}"; do
  export ${var#dev_}=${!var}
done

echo $TEST
```

Running it yelds the error:
```
test.sh: line 6: export: `TABS\nAND': not a valid identifier
```

The fix is to make sure we use quotes when assigning the value of the new env var in line 6:
```bash
set -e;

export dev_TEST="VALUE WITH 	TABS\nAND NEWLINE"

for var in "${!dev_@}"; do
  export ${var#dev_}="${!var}"
done

echo $TEST
```

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
