### PR TITLE
feat: added a proxy API to fetch a transaction from the fullnode

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -573,6 +573,8 @@ functions:
             parameters:
               paths:
                 txId: true
+          throttling:
+            maxRequestsPerSecond: 50
     warmup:
       walletWarmer:
         enabled: false
@@ -588,6 +590,8 @@ functions:
             parameters:
               paths:
                 txId: true
+          throttling:
+            maxRequestsPerSecond: 10
     warmup:
       walletWarmer:
         enabled: false
@@ -599,6 +603,8 @@ functions:
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
+          throttling:
+            maxRequestsPerSecond: 20
     warmup:
       walletWarmer:
         enabled: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -420,6 +420,17 @@ functions:
     warmup:
       walletWarmer:
         enabled: false
+  proxyGetTxById:
+    handler: src/api/fullnodeProxy.getTransactionById
+    events:
+      - http:
+        path: wallet/proxy/transactions/{txId}
+        method: get
+        cors: true
+        authorizer: ${self:custom.authorizer.walletBearer}
+    warmup:
+      walletWarmer:
+        enabled: false
   wsConnect:
     handler: src/ws/connection.connect
     timeout: 1

--- a/serverless.yml
+++ b/serverless.yml
@@ -420,17 +420,6 @@ functions:
     warmup:
       walletWarmer:
         enabled: false
-  proxyGetTxById:
-    handler: src/api/fullnodeProxy.getTransactionById
-    events:
-      - http:
-        path: wallet/proxy/transactions/{txId}
-        method: get
-        cors: true
-        authorizer: ${self:custom.authorizer.walletBearer}
-    warmup:
-      walletWarmer:
-        enabled: false
   wsConnect:
     handler: src/ws/connection.connect
     timeout: 1
@@ -569,6 +558,47 @@ functions:
             parameters:
               paths:
                 txId: true
+    warmup:
+      walletWarmer:
+        enabled: false
+  proxiedGetTxById:
+    handler: src/api/fullnodeProxy.getTransactionById
+    events:
+      - http:
+          path: wallet/proxy/transactions/{txId}
+          method: get
+          cors: true
+          authorizer: ${self:custom.authorizer.walletBearer}
+          request:
+            parameters:
+              paths:
+                txId: true
+    warmup:
+      walletWarmer:
+        enabled: false
+  proxiedGetConfirmationData:
+    handler: src/api/fullnodeProxy.getConfirmationData
+    events:
+      - http:
+          path: wallet/proxy/transactions/{txId}/confirmation_data
+          method: get
+          cors: true
+          authorizer: ${self:custom.authorizer.walletBearer}
+          request:
+            parameters:
+              paths:
+                txId: true
+    warmup:
+      walletWarmer:
+        enabled: false
+  proxiedGraphvizNeighborsQuery:
+    handler: src/api/fullnodeProxy.queryGraphvizNeighbors
+    events:
+      - http:
+          path: wallet/proxy/graphviz/neighbors
+          method: get
+          cors: true
+          authorizer: ${self:custom.authorizer.walletBearer}
     warmup:
       walletWarmer:
         enabled: false

--- a/src/api/fullnodeProxy.ts
+++ b/src/api/fullnodeProxy.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import 'source-map-support/register';
+
+import { APIGatewayProxyHandler } from 'aws-lambda';
+import { ApiError } from '@src/api/errors';
+import { closeDbAndGetError } from '@src/api/utils';
+import { walletIdProxyHandler } from '@src/commons';
+import fullnode from '@src/fullnode';
+import {
+  closeDbConnection,
+  getDbConnection,
+} from '@src/utils';
+import middy from '@middy/core';
+import cors from '@middy/http-cors';
+import Joi from 'joi';
+
+const mysql = getDbConnection();
+
+const paramsSchema = Joi.object({
+  txId: Joi.string()
+    .alphanum()
+    .required(),
+});
+
+/*
+ * Get a transaction from the fullnode
+ *
+ * This lambda is called by API Gateway on GET /wallet/proxy/transactions/:id
+ */
+export const getTransactionById: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (_walletId: string, event) => {
+  const params = event.queryStringParameters || {};
+
+  const { value, error } = paramsSchema.validate(params, {
+    abortEarly: false,
+    convert: false,
+  });
+
+  if (error) {
+    const details = error.details.map((err) => ({
+      message: err.message,
+      path: err.path,
+    }));
+
+    return closeDbAndGetError(mysql, ApiError.INVALID_PAYLOAD, { details });
+  }
+
+  const txId = value.txId;
+  const transaction = await fullnode.downloadTx(txId);
+
+  await closeDbConnection(mysql);
+
+  return {
+    statusCode: 200,
+    body: JSON.stringify(transaction),
+  };
+})).use(cors());

--- a/src/api/fullnodeProxy.ts
+++ b/src/api/fullnodeProxy.ts
@@ -53,7 +53,7 @@ const graphvizValidator = Joi.object({
  */
 export const getTransactionById: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (_walletId: string, event) => {
   const params = event.pathParameters || {};
-  const validationResult: ParamValidationResult = validateParams(txIdValidator, params);
+  const validationResult: ParamValidationResult<GetTxByIdParams> = validateParams(txIdValidator, params);
 
   if (validationResult.error) {
     return closeDbAndGetError(mysql, ApiError.INVALID_PAYLOAD, {
@@ -61,7 +61,7 @@ export const getTransactionById: APIGatewayProxyHandler = middy(walletIdProxyHan
     });
   }
 
-  const { txId } = validationResult.value as GetTxByIdParams;
+  const { txId } = validationResult.value;
   const transaction = await fullnode.downloadTx(txId);
 
   await closeDbConnection(mysql);
@@ -79,7 +79,7 @@ export const getTransactionById: APIGatewayProxyHandler = middy(walletIdProxyHan
  */
 export const getConfirmationData: APIGatewayProxyHandler = middy(walletIdProxyHandler(async (_walletId: string, event) => {
   const params = event.pathParameters || {};
-  const validationResult: ParamValidationResult = validateParams(txIdValidator, params);
+  const validationResult: ParamValidationResult<GetConfirmationDataParams> = validateParams(txIdValidator, params);
 
   if (validationResult.error) {
     return closeDbAndGetError(mysql, ApiError.INVALID_PAYLOAD, {
@@ -87,7 +87,7 @@ export const getConfirmationData: APIGatewayProxyHandler = middy(walletIdProxyHa
     });
   }
 
-  const { txId } = validationResult.value as GetConfirmationDataParams;
+  const { txId } = validationResult.value;
   const confirmationData = await fullnode.getConfirmationData(txId);
 
   await closeDbConnection(mysql);
@@ -106,7 +106,7 @@ export const getConfirmationData: APIGatewayProxyHandler = middy(walletIdProxyHa
 export const queryGraphvizNeighbors: APIGatewayProxyHandler = middy(
   walletIdProxyHandler(async (_walletId: string, event) => {
     const params = event.queryStringParameters || {};
-    const validationResult: ParamValidationResult = validateParams(graphvizValidator, params, {
+    const validationResult: ParamValidationResult<GraphvizParams> = validateParams<GraphvizParams>(graphvizValidator, params, {
       abortEarly: false,
       // Since we receive params as queryString,
       // we want Joi to convert maxLevel from string to number
@@ -123,7 +123,7 @@ export const queryGraphvizNeighbors: APIGatewayProxyHandler = middy(
       txId,
       graphType,
       maxLevel,
-    } = validationResult.value as GraphvizParams;
+    } = validationResult.value;
 
     const graphVizData = await fullnode.queryGraphvizNeighbors(txId, graphType, maxLevel);
 

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -114,7 +114,7 @@ export const validateParams = <ResultType>(
 
   const { error, value } = result;
 
-  if (result.error) {
+  if (error) {
     const details = error.details.map((err) => ({
       message: err.message,
       path: err.path,

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -102,14 +102,14 @@ export const pushProviderRegexPattern = (): RegExp => {
   return new RegExp(`^(?:${options})$`);
 };
 
-export const validateParams = (
+export const validateParams = <ResultType>(
   validator: Schema,
   params: unknown,
   validatorOptions: ValidationOptions = {
     abortEarly: false,
     convert: false,
   },
-): ParamValidationResult => {
+): ParamValidationResult<ResultType> => {
   const result: ValidationResult = validator.validate(params, validatorOptions);
 
   const { error, value } = result;

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -8,9 +8,18 @@
 import { APIGatewayProxyResult, APIGatewayProxyEvent } from 'aws-lambda';
 import { ServerlessMysql } from 'serverless-mysql';
 import middy from '@middy/core';
+import Joi, {
+  Schema,
+  ValidationOptions,
+  ValidationResult,
+} from 'joi';
 
 import { ApiError } from '@src/api/errors';
-import { PushProvider, StringMap } from '@src/types';
+import {
+  PushProvider,
+  StringMap,
+  ParamValidationResult,
+} from '@src/types';
 import { closeDbConnection } from '@src/utils';
 
 export const STATUS_CODE_TABLE = {
@@ -91,4 +100,34 @@ export const pushProviderRegexPattern = (): RegExp => {
   const entries = Object.values(PushProvider);
   const options = entries.join('|');
   return new RegExp(`^(?:${options})$`);
+};
+
+export const validateParams = (
+  validator: Schema,
+  params: unknown,
+  validatorOptions: ValidationOptions = {
+    abortEarly: false,
+    convert: false,
+  },
+): ParamValidationResult => {
+  const result: ValidationResult = validator.validate(params, validatorOptions);
+
+  const { error, value } = result;
+
+  if (result.error) {
+    const details = error.details.map((err) => ({
+      message: err.message,
+      path: err.path,
+    }));
+
+    return {
+      error: true,
+      details,
+    };
+  }
+
+  return {
+    error: false,
+    value,
+  };
 };

--- a/src/fullnode.ts
+++ b/src/fullnode.ts
@@ -22,7 +22,7 @@ export const create = (baseURL = BASE_URL): any => {
     timeout: TIMEOUT,
   });
 
-  const downloadTx = async (txId) => {
+  const downloadTx = async (txId: string) => {
     const response = await api.get(`transaction?id=${txId}`, {
       data: null,
       headers: { 'content-type': 'application/json' },
@@ -55,6 +55,7 @@ export const create = (baseURL = BASE_URL): any => {
   };
 
   return {
+    api, // exported so we can mock it on the tests
     downloadTx,
     getConfirmationData,
     queryGraphvizNeighbors,

--- a/src/fullnode.ts
+++ b/src/fullnode.ts
@@ -43,7 +43,7 @@ export const create = (baseURL = BASE_URL): any => {
   const queryGraphvizNeighbors = async (
     txId: string,
     graphType: string,
-    maxLevel: string,
+    maxLevel: number,
   ) => {
     const url = `graphviz/neighbours.dot/?tx=${txId}&graph_type=${graphType}&max_level=${maxLevel}`;
     const response = await api.get(url, {

--- a/src/fullnode.ts
+++ b/src/fullnode.ts
@@ -31,7 +31,34 @@ export const create = (baseURL = BASE_URL): any => {
     return response.data;
   };
 
-  return { downloadTx };
+  const getConfirmationData = async (txId: string) => {
+    const response = await api.get(`transaction_acc_weight?id=${txId}`, {
+      data: null,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    return response.data;
+  };
+
+  const queryGraphvizNeighbors = async (
+    txId: string,
+    graphType: string,
+    maxLevel: string,
+  ) => {
+    const url = `graphviz/neighbours.dot/?tx=${txId}&graph_type=${graphType}&max_level=${maxLevel}`;
+    const response = await api.get(url, {
+      data: null,
+      headers: { 'content-type': 'application/json' },
+    });
+
+    return response.data;
+  };
+
+  return {
+    downloadTx,
+    getConfirmationData,
+    queryGraphvizNeighbors,
+  };
 };
 
 export default create();

--- a/src/types.ts
+++ b/src/types.ts
@@ -725,6 +725,26 @@ export interface TxByIdToken {
   tokenSymbol: string;
 }
 
+export interface ParamValidationResult {
+  error: boolean;
+  details?: { message: string, path: (string | number)[] }[],
+  value?: any;
+}
+
+export interface GraphvizParams {
+  txId: string;
+  graphType: string;
+  maxLevel: number;
+}
+
+export interface GetTxByIdParams {
+  txId: string;
+}
+
+export interface GetConfirmationDataParams {
+  txId: string;
+}
+
 export interface SendNotificationToDevice {
   deviceId: string,
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -725,10 +725,10 @@ export interface TxByIdToken {
   tokenSymbol: string;
 }
 
-export interface ParamValidationResult {
+export interface ParamValidationResult<ValueType> {
   error: boolean;
   details?: { message: string, path: (string | number)[] }[],
-  value?: any;
+  value?: ValueType;
 }
 
 export interface GraphvizParams {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1533,15 +1533,36 @@ test('GET /wallet/proxy/transactions/{txId}', async () => {
   const mockFullnodeResponse = jest.fn(() => Promise.resolve(mockData));
   spy.mockImplementation(mockFullnodeResponse);
 
-  const event = makeGatewayEventWithAuthorizer('my-wallet', {
+  let event = makeGatewayEventWithAuthorizer('my-wallet', {
     txId: '000011f5cd1c2bcb7e5e91567666042d8681deeca96263bca60f10c528b9af32',
   });
-  const result = await getTransactionById(event, null, null) as APIGatewayProxyResult;
-  const returnBody = JSON.parse(result.body as string);
+  let result = await getTransactionById(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
 
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody).toStrictEqual(mockData);
+
+  event = makeGatewayEventWithAuthorizer('my-wallet', {});
+  result = await getTransactionById(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(400);
+  expect(returnBody.success).toBe(false);
+  expect(returnBody).toMatchInlineSnapshot(`
+    Object {
+      "details": Array [
+        Object {
+          "message": "\\"txId\\" is required",
+          "path": Array [
+            "txId",
+          ],
+        },
+      ],
+      "error": "invalid-payload",
+      "success": false,
+    }
+  `);
 });
 
 test('GET /wallet/proxy/confirmation_data/{txId}', async () => {
@@ -1560,15 +1581,37 @@ test('GET /wallet/proxy/confirmation_data/{txId}', async () => {
   const mockFullnodeResponse = jest.fn(() => Promise.resolve(mockData));
   spy.mockImplementation(mockFullnodeResponse);
 
-  const event = makeGatewayEventWithAuthorizer('my-wallet', {
+  let event = makeGatewayEventWithAuthorizer('my-wallet', {
     txId: '000011f5cd1c2bcb7e5e91567666042d8681deeca96263bca60f10c528b9af32',
   });
-  const result = await getConfirmationData(event, null, null) as APIGatewayProxyResult;
-  const returnBody = JSON.parse(result.body as string);
+  let result = await getConfirmationData(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
 
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
   expect(returnBody).toStrictEqual(mockData);
+
+  // Missing txId
+  event = makeGatewayEventWithAuthorizer('my-wallet', {});
+  result = await getConfirmationData(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(400);
+  expect(returnBody.success).toBe(false);
+  expect(returnBody).toMatchInlineSnapshot(`
+    Object {
+      "details": Array [
+        Object {
+          "message": "\\"txId\\" is required",
+          "path": Array [
+            "txId",
+          ],
+        },
+      ],
+      "error": "invalid-payload",
+      "success": false,
+    }
+  `);
 });
 
 test('GET /wallet/proxy/graphviz/neighbors', async () => {
@@ -1592,6 +1635,7 @@ test('GET /wallet/proxy/graphviz/neighbors', async () => {
   expect(result.statusCode).toBe(200);
   expect(returnBody).toStrictEqual(mockData);
 
+  // Missing a single attribute
   event = makeGatewayEventWithAuthorizer('my-wallet', {
     txId: '000011f5cd1c2bcb7e5e91567666042d8681deeca96263bca60f10c528b9af32',
     graphType: 'verification',
@@ -1600,5 +1644,50 @@ test('GET /wallet/proxy/graphviz/neighbors', async () => {
   result = await queryGraphvizNeighbors(event, null, null) as APIGatewayProxyResult;
   returnBody = JSON.parse(result.body as string);
   expect(result.statusCode).toBe(400);
-  expect(returnBody).toMatchInlineSnapshot();
+  expect(returnBody).toMatchInlineSnapshot(`
+    Object {
+      "details": Array [
+        Object {
+          "message": "\\"maxLevel\\" is required",
+          "path": Array [
+            "maxLevel",
+          ],
+        },
+      ],
+      "error": "invalid-payload",
+      "success": false,
+    }
+  `);
+
+  // Missing all attributes
+  event = makeGatewayEventWithAuthorizer('my-wallet', {});
+  result = await queryGraphvizNeighbors(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(400);
+  expect(returnBody).toMatchInlineSnapshot(`
+    Object {
+      "details": Array [
+        Object {
+          "message": "\\"txId\\" is required",
+          "path": Array [
+            "txId",
+          ],
+        },
+        Object {
+          "message": "\\"graphType\\" is required",
+          "path": Array [
+            "graphType",
+          ],
+        },
+        Object {
+          "message": "\\"maxLevel\\" is required",
+          "path": Array [
+            "maxLevel",
+          ],
+        },
+      ],
+      "error": "invalid-payload",
+      "success": false,
+    }
+  `);
 });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1581,14 +1581,24 @@ test('GET /wallet/proxy/graphviz/neighbors', async () => {
   const mockFullnodeResponse = jest.fn(() => Promise.resolve(mockData));
   spy.mockImplementation(mockFullnodeResponse);
 
-  const event = makeGatewayEventWithAuthorizer('my-wallet', {
+  let event = makeGatewayEventWithAuthorizer('my-wallet', {
     txId: '000011f5cd1c2bcb7e5e91567666042d8681deeca96263bca60f10c528b9af32',
     graphType: 'verification',
     maxLevel: '1',
   });
-  const result = await queryGraphvizNeighbors(event, null, null) as APIGatewayProxyResult;
-  const returnBody = JSON.parse(result.body as string);
+  let result = await queryGraphvizNeighbors(event, null, null) as APIGatewayProxyResult;
+  let returnBody = JSON.parse(result.body as string);
 
   expect(result.statusCode).toBe(200);
   expect(returnBody).toStrictEqual(mockData);
+
+  event = makeGatewayEventWithAuthorizer('my-wallet', {
+    txId: '000011f5cd1c2bcb7e5e91567666042d8681deeca96263bca60f10c528b9af32',
+    graphType: 'verification',
+  });
+
+  result = await queryGraphvizNeighbors(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+  expect(result.statusCode).toBe(400);
+  expect(returnBody).toMatchInlineSnapshot();
 });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1565,7 +1565,7 @@ test('GET /wallet/proxy/transactions/{txId}', async () => {
   `);
 });
 
-test('GET /wallet/proxy/confirmation_data/{txId}', async () => {
+test('GET /wallet/proxy/{txId}/confirmation_data', async () => {
   expect.hasAssertions();
 
   const mockData = {

--- a/tests/fullnode.test.ts
+++ b/tests/fullnode.test.ts
@@ -1,0 +1,58 @@
+import fullnode from '@src/fullnode';
+
+test('downloadTx', async () => {
+  expect.hasAssertions();
+
+  const mockData = {
+    success: true,
+    tx: {
+      hash: 'tx1',
+    },
+    meta: {},
+  };
+
+  const apiGetSpy = jest.spyOn(fullnode.api, 'get');
+  apiGetSpy.mockImplementation(() => Promise.resolve({
+    status: 200,
+    data: mockData,
+  }));
+
+  const response = await fullnode.downloadTx('tx1');
+  expect(response).toStrictEqual(mockData);
+});
+
+test('getConfirmationData', async () => {
+  expect.hasAssertions();
+
+  const mockData = {
+    success: true,
+    accumulated_weight: 67.45956109191802,
+    accumulated_bigger: true,
+    stop_value: 67.45416781056525,
+    confirmation_level: 1,
+  };
+
+  const apiGetSpy = jest.spyOn(fullnode.api, 'get');
+  apiGetSpy.mockImplementation(() => Promise.resolve({
+    status: 200,
+    data: mockData,
+  }));
+
+  const response = await fullnode.getConfirmationData('tx1');
+  expect(response).toStrictEqual(mockData);
+});
+
+test('queryGraphvizNeighbors', async () => {
+  expect.hasAssertions();
+
+  const mockData = 'diagraph {}';
+
+  const apiGetSpy = jest.spyOn(fullnode.api, 'get');
+  apiGetSpy.mockImplementation(() => Promise.resolve({
+    status: 200,
+    data: mockData,
+  }));
+
+  const response = await fullnode.queryGraphvizNeighbors('tx1', 'test', 1);
+  expect(response).toStrictEqual(mockData);
+});


### PR DESCRIPTION
### Acceptance Criteria
- We should have "proxied" methods for querying the fullnode
- We should have the same global rate limits as we have on our public fullnodes

## On using lambdas instead of ApiGateway directly

We could setup the proxy directly on `ApiGateway`, removing the need for the proxy lambdas (which are currently only making the request and returning the response transparently

That would avoid entirely the lambda calls and decrease our costs

The problem with that approach is that it is currently not supported by the serverless syntax, there is a [serverless plugin](https://www.serverless.com/plugins/serverless-apigateway-service-proxy) to configure proxy integrations on the ApiGateway but it does not support [HTTP integrations](https://docs.aws.amazon.com/apigateway/latest/developerguide/setup-http-integrations.html), which would be our usecase

I could try to implement it using the `CloudFormation` syntax on the serverless file, but it would take some time since I'm not quite used to it and would need some time to study it.

Keeping that and the fact that this API is needed to finish the QA on the wallet-desktop and deploy the wallet-service facade for internal testing, I would suggest deploying the current solution using lambdas and create an issue to refactor this to use `ApiGateway` directly


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
