### PR TITLE
chore: fixed testnet WS_DOMAIN env var

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -22,7 +22,7 @@ env:
     dev_WALLET_SERVICE_LAMBDA_ENDPOINT: "https://lambda.eu-central-1.amazonaws.com"
     dev_PUSH_NOTIFICATION_ENABLED: "false"
     testnet_DEFAULT_SERVER: "https://wallet-service.private-nodes.testnet.hathor.network/v1a/"
-    testnet_WS_DOMAIN: "ws.testnet.wallet-service.hathor.network"
+    testnet_WS_DOMAIN: "ws.wallet-service.testnet.hathor.network"
     testnet_NETWORK: "testnet"
     testnet_LOG_LEVEL: "info"
     testnet_EXPLORER_STAGE: "testnet"


### PR DESCRIPTION
### Acceptance Criteria
- We had an invalid env variable for `WS_DOMAIN` on `testnet` causing errors while a client was trying to connect to it


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
