### PR TITLE
fix: updated neighbors to neighbours

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -600,10 +600,10 @@ functions:
       walletWarmer:
         enabled: false
   proxiedGraphvizNeighborsQuery:
-    handler: src/api/fullnodeProxy.queryGraphvizNeighbors
+    handler: src/api/fullnodeProxy.queryGraphvizNeighbours
     events:
       - http:
-          path: wallet/proxy/graphviz/neighbors
+          path: wallet/proxy/graphviz/neighbours
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}

--- a/src/api/fullnodeProxy.ts
+++ b/src/api/fullnodeProxy.ts
@@ -101,9 +101,9 @@ export const getConfirmationData: APIGatewayProxyHandler = middy(walletIdProxyHa
 /*
  * Makes graphviz queries on the fullnode
  *
- * This lambda is called by API Gateway on GET /wallet/proxy/graphviz/neighbors
+ * This lambda is called by API Gateway on GET /wallet/proxy/graphviz/neighbours
  */
-export const queryGraphvizNeighbors: APIGatewayProxyHandler = middy(
+export const queryGraphvizNeighbours: APIGatewayProxyHandler = middy(
   walletIdProxyHandler(async (_walletId: string, event) => {
     const params = event.queryStringParameters || {};
     const validationResult: ParamValidationResult<GraphvizParams> = validateParams<GraphvizParams>(graphvizValidator, params, {
@@ -125,7 +125,7 @@ export const queryGraphvizNeighbors: APIGatewayProxyHandler = middy(
       maxLevel,
     } = validationResult.value;
 
-    const graphVizData = await fullnode.queryGraphvizNeighbors(txId, graphType, maxLevel);
+    const graphVizData = await fullnode.queryGraphvizNeighbours(txId, graphType, maxLevel);
 
     await closeDbConnection(mysql);
 

--- a/src/fullnode.ts
+++ b/src/fullnode.ts
@@ -40,7 +40,7 @@ export const create = (baseURL = BASE_URL): any => {
     return response.data;
   };
 
-  const queryGraphvizNeighbors = async (
+  const queryGraphvizNeighbours = async (
     txId: string,
     graphType: string,
     maxLevel: number,
@@ -58,7 +58,7 @@ export const create = (baseURL = BASE_URL): any => {
     api, // exported so we can mock it on the tests
     downloadTx,
     getConfirmationData,
-    queryGraphvizNeighbors,
+    queryGraphvizNeighbours,
   };
 };
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -4,18 +4,17 @@ import { get as addressesGet, checkMine } from '@src/api/addresses';
 import { get as newAddressesGet } from '@src/api/newAddresses';
 import { get as balancesGet } from '@src/api/balances';
 import { get as txHistoryGet } from '@src/api/txhistory';
-import { get as walletTokensGet } from '@src/api/tokens';
+import { get as walletTokensGet, getTokenDetails } from '@src/api/tokens';
 import { get as getVersionDataGet } from '@src/api/version';
 import {
   getTransactionById,
   getConfirmationData,
-  queryGraphvizNeighbors,
+  queryGraphvizNeighbours,
 } from '@src/api/fullnodeProxy';
 import { create as txProposalCreate } from '@src/api/txProposalCreate';
 import { send as txProposalSend } from '@src/api/txProposalSend';
 import { destroy as txProposalDestroy } from '@src/api/txProposalDestroy';
 import { getFilteredUtxos, getFilteredTxOutputs } from '@src/api/txOutputs';
-import { getTokenDetails } from '@src/api/tokens';
 import {
   get as walletGet,
   load as walletLoad,
@@ -1614,12 +1613,12 @@ test('GET /wallet/proxy/{txId}/confirmation_data', async () => {
   `);
 });
 
-test('GET /wallet/proxy/graphviz/neighbors', async () => {
+test('GET /wallet/proxy/graphviz/neighbours', async () => {
   expect.hasAssertions();
 
   const mockData = 'digraph {}';
 
-  const spy = jest.spyOn(fullnode, 'queryGraphvizNeighbors');
+  const spy = jest.spyOn(fullnode, 'queryGraphvizNeighbours');
 
   const mockFullnodeResponse = jest.fn(() => Promise.resolve(mockData));
   spy.mockImplementation(mockFullnodeResponse);
@@ -1629,7 +1628,7 @@ test('GET /wallet/proxy/graphviz/neighbors', async () => {
     graphType: 'verification',
     maxLevel: '1',
   });
-  let result = await queryGraphvizNeighbors(event, null, null) as APIGatewayProxyResult;
+  let result = await queryGraphvizNeighbours(event, null, null) as APIGatewayProxyResult;
   let returnBody = JSON.parse(result.body as string);
 
   expect(result.statusCode).toBe(200);
@@ -1641,7 +1640,7 @@ test('GET /wallet/proxy/graphviz/neighbors', async () => {
     graphType: 'verification',
   });
 
-  result = await queryGraphvizNeighbors(event, null, null) as APIGatewayProxyResult;
+  result = await queryGraphvizNeighbours(event, null, null) as APIGatewayProxyResult;
   returnBody = JSON.parse(result.body as string);
   expect(result.statusCode).toBe(400);
   expect(returnBody).toMatchInlineSnapshot(`
@@ -1661,7 +1660,7 @@ test('GET /wallet/proxy/graphviz/neighbors', async () => {
 
   // Missing all attributes
   event = makeGatewayEventWithAuthorizer('my-wallet', {});
-  result = await queryGraphvizNeighbors(event, null, null) as APIGatewayProxyResult;
+  result = await queryGraphvizNeighbours(event, null, null) as APIGatewayProxyResult;
   returnBody = JSON.parse(result.body as string);
   expect(result.statusCode).toBe(400);
   expect(returnBody).toMatchInlineSnapshot(`

--- a/tests/fullnode.test.ts
+++ b/tests/fullnode.test.ts
@@ -42,7 +42,7 @@ test('getConfirmationData', async () => {
   expect(response).toStrictEqual(mockData);
 });
 
-test('queryGraphvizNeighbors', async () => {
+test('queryGraphvizNeighbours', async () => {
   expect.hasAssertions();
 
   const mockData = 'diagraph {}';
@@ -53,6 +53,6 @@ test('queryGraphvizNeighbors', async () => {
     data: mockData,
   }));
 
-  const response = await fullnode.queryGraphvizNeighbors('tx1', 'test', 1);
+  const response = await fullnode.queryGraphvizNeighbours('tx1', 'test', 1);
   expect(response).toStrictEqual(mockData);
 });


### PR DESCRIPTION
### Acceptance Criteria
- Neighbors should be Neighbours, as this is what the fullnode uses and the library expects


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
