### PR TITLE
chore: increased ws timeouts to 2s

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -68,6 +68,17 @@ custom:
         treatMissingData: notBreaching
         alarmActions:
           - minor
+      wsLambdasExecutionDuration:
+        description: "WebSocket lambda took too long to execute"
+        namespace: 'AWS/Lambda'
+        metric: "Duration"
+        statistic: Average
+        threshold: 1000 # This is in milliseconds
+        period: 60
+        evaluationPeriods: 1
+        comparisonOperator: GreaterThanThreshold
+        alarmActions:
+          - minor
     alarms: # Alarms that will be applied to all functions
       - majorFunctionErrors
       - minorFunctionErrors
@@ -437,6 +448,8 @@ functions:
     warmup:
       walletWarmer:
         enabled: false
+    alarms:
+      - wsLambdasExecutionDuration
   wsJoin:
     handler: src/ws/join.handler
     timeout: 2
@@ -446,6 +459,8 @@ functions:
     warmup:
       walletWarmer:
         enabled: false
+    alarms:
+      - wsLambdasExecutionDuration
   wsTxNotifyNew:
     handler: src/ws/txNotify.onNewTx
     timeout: 2
@@ -461,30 +476,40 @@ functions:
     warmup:
       walletWarmer:
         enabled: false
+    alarms:
+      - wsLambdasExecutionDuration
   wsTxNotifyUpdate:
     handler: src/ws/txNotify.onUpdateTx
     timeout: 2
     warmup:
       walletWarmer:
         enabled: false
+    alarms:
+      - wsLambdasExecutionDuration
   wsAdminBroadcast:
     handler: src/ws/admin.broadcast
     timeout: 2
     warmup:
       walletWarmer:
         enabled: false
+    alarms:
+      - wsLambdasExecutionDuration
   wsAdminDisconnect:
     handler: src/ws/admin.disconnect
     timeout: 2
     warmup:
       walletWarmer:
         enabled: false
+    alarms:
+      - wsLambdasExecutionDuration
   wsAdminMulticast:
     handler: src/ws/admin.multicast
     timeout: 2
     warmup:
       walletWarmer:
         enabled: false
+    alarms:
+      - wsLambdasExecutionDuration
   authTokenApi:
     handler: src/api/auth.tokenHandler
     timeout: 6

--- a/serverless.yml
+++ b/serverless.yml
@@ -426,7 +426,7 @@ functions:
         enabled: false
   wsConnect:
     handler: src/ws/connection.connect
-    timeout: 1
+    timeout: 2
     events:
       - websocket:
           route: $connect
@@ -439,7 +439,7 @@ functions:
         enabled: false
   wsJoin:
     handler: src/ws/join.handler
-    timeout: 1
+    timeout: 2
     events:
       - websocket:
           route: join
@@ -448,7 +448,7 @@ functions:
         enabled: false
   wsTxNotifyNew:
     handler: src/ws/txNotify.onNewTx
-    timeout: 1
+    timeout: 2
     events:
       - sqs:
           arn:
@@ -463,25 +463,25 @@ functions:
         enabled: false
   wsTxNotifyUpdate:
     handler: src/ws/txNotify.onUpdateTx
-    timeout: 1
+    timeout: 2
     warmup:
       walletWarmer:
         enabled: false
   wsAdminBroadcast:
     handler: src/ws/admin.broadcast
-    timeout: 1
+    timeout: 2
     warmup:
       walletWarmer:
         enabled: false
   wsAdminDisconnect:
     handler: src/ws/admin.disconnect
-    timeout: 1
+    timeout: 2
     warmup:
       walletWarmer:
         enabled: false
   wsAdminMulticast:
     handler: src/ws/admin.multicast
-    timeout: 1
+    timeout: 2
     warmup:
       walletWarmer:
         enabled: false

--- a/serverless.yml
+++ b/serverless.yml
@@ -448,7 +448,7 @@ functions:
     warmup:
       walletWarmer:
         enabled: false
-    alarms:
+    alarms: # This gets merged with the global alarms
       - wsLambdasExecutionDuration
   wsJoin:
     handler: src/ws/join.handler

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -42,6 +42,8 @@ export const get = middy(walletIdProxyHandler(async (walletId) => {
 const getTokenDetailsParamsSchema = Joi.object({
   token_id: Joi.string()
     .alphanum()
+    .min(64)
+    .max(64)
     .required(),
 });
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1329,7 +1329,7 @@ test('GET /wallet/tokens/token_id/details', async () => {
     readyAt: 10001,
   }]);
 
-  let event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: 'unknown' });
+  let event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: '000000007bee89ef2d301ca6f7a1aa997f618011ea5116ed261aa82401513284' });
   let result = await getTokenDetails(event, null, null) as APIGatewayProxyResult;
   let returnBody = JSON.parse(result.body as string);
 
@@ -1346,8 +1346,8 @@ test('GET /wallet/tokens/token_id/details', async () => {
   expect(returnBody.details[0]).toStrictEqual({ message: '"token_id" is required', path: ['token_id'] });
 
   // add tokens
-  const token1 = { id: 'token1', name: 'MyToken1', symbol: 'MT1' };
-  const token2 = { id: 'token2', name: 'MyToken2', symbol: 'MT2' };
+  const token1 = { id: '000000001a234f4239b762a4d713556bc810d1c3d18fd5569dc96119cc496dd0', name: 'MyToken1', symbol: 'MT1' };
+  const token2 = { id: '0000052b5a0c69783b70cabf0c17f357bd6eef86cd0d93d8b59862f56943137a', name: 'MyToken2', symbol: 'MT2' };
 
   await addToTokenTable(mysql, [
     { id: token1.id, name: token1.name, symbol: token1.symbol, transactions: 0 },


### PR DESCRIPTION
## Motivation

We are receiving timeout alerts for the websocket lambdas on wallet-service

Upon investigation, I've detected that the timeouts are currently configured to 1s

It does make sense to have a low timeout value for those APIs as they should run in under 50ms per call

The problem is that those lambdas need to query the MySQL database to fetch the walletId from the requester

The timeout is happening because the connection to the database (which happens only once in a while for multiple lambda calls) takes up to 1s because of the TLS handshake.

Since the lambda always times out, the connection never gets re-used, causing every lambda call to create a new MySQL connection and timeout because of the TLS handshake time.

This is not affecting the wallets because the timeout happens after the client gets a response, so that's why it took us a while to receive this error


### Acceptance Criteria
- We should increase the timeouts on the websocket lambdas to fix https://github.com/HathorNetwork/on-call-incidents/issues/87
- We should create alarms if the average of duration of websocket lambdas is greater than 1s

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
