### PR TITLE
fix: throw error when htr is requested on getTokenDetails

### DIFF
--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -13,7 +13,7 @@ import {
 } from '@src/types';
 import { getDbConnection } from '@src/utils';
 import { ApiError } from '@src/api/errors';
-import { closeDbAndGetError, warmupMiddleware } from '@src/api/utils';
+import { closeDbAndGetError, warmupMiddleware, txIdJoiValidator } from '@src/api/utils';
 import Joi from 'joi';
 import { constants } from '@hathor/wallet-lib';
 import middy from '@middy/core';
@@ -40,11 +40,7 @@ export const get = middy(walletIdProxyHandler(async (walletId) => {
   .use(warmupMiddleware());
 
 const getTokenDetailsParamsSchema = Joi.object({
-  token_id: Joi.string()
-    .alphanum()
-    .min(64)
-    .max(64)
-    .required(),
+  token_id: txIdJoiValidator.required(),
 });
 
 /*

--- a/src/api/tokens.ts
+++ b/src/api/tokens.ts
@@ -72,6 +72,14 @@ export const getTokenDetails = middy(walletIdProxyHandler(async (walletId, event
   const tokenId = value.token_id;
   const tokenInfo: TokenInfo = await getTokenInformation(mysql, tokenId);
 
+  if (tokenId === constants.HATHOR_TOKEN_CONFIG.uid) {
+    const details = [{
+      message: 'Invalid tokenId',
+    }];
+
+    return closeDbAndGetError(mysql, ApiError.INVALID_PAYLOAD, { details });
+  }
+
   if (!tokenInfo) {
     const details = [{
       message: 'Token not found',

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -131,3 +131,8 @@ export const validateParams = <ResultType>(
     value,
   };
 };
+
+/**
+ * This should be used inside a Joi validator object
+ */
+export const txIdJoiValidator = Joi.string().alphanum().min(64).max(64);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1394,6 +1394,14 @@ test('GET /wallet/tokens/token_id/details', async () => {
   expect(returnBody.details.authorities.mint).toStrictEqual(true);
   expect(returnBody.details.authorities.melt).toStrictEqual(true);
   expect(returnBody.details.tokenInfo).toStrictEqual(token2);
+
+  event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: constants.HATHOR_TOKEN_CONFIG.uid });
+  result = await getTokenDetails(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(400);
+  expect(returnBody.success).toBe(false);
+  expect(returnBody.details).toStrictEqual([{ message: 'Invalid tokenId' }]);
 });
 
 test('GET /wallet/utxos', async () => {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -33,6 +33,7 @@ import { walletUtils, constants, network, HathorWalletServiceWallet } from '@hat
 import bitcore from 'bitcore-lib';
 import {
   ADDRESSES,
+  TX_IDS,
   XPUBKEY,
   AUTH_XPUBKEY,
   TEST_SEED,
@@ -1329,7 +1330,7 @@ test('GET /wallet/tokens/token_id/details', async () => {
     readyAt: 10001,
   }]);
 
-  let event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: '000000007bee89ef2d301ca6f7a1aa997f618011ea5116ed261aa82401513284' });
+  let event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: TX_IDS[0] });
   let result = await getTokenDetails(event, null, null) as APIGatewayProxyResult;
   let returnBody = JSON.parse(result.body as string);
 
@@ -1346,8 +1347,8 @@ test('GET /wallet/tokens/token_id/details', async () => {
   expect(returnBody.details[0]).toStrictEqual({ message: '"token_id" is required', path: ['token_id'] });
 
   // add tokens
-  const token1 = { id: '000000001a234f4239b762a4d713556bc810d1c3d18fd5569dc96119cc496dd0', name: 'MyToken1', symbol: 'MT1' };
-  const token2 = { id: '0000052b5a0c69783b70cabf0c17f357bd6eef86cd0d93d8b59862f56943137a', name: 'MyToken2', symbol: 'MT2' };
+  const token1 = { id: TX_IDS[1], name: 'MyToken1', symbol: 'MT1' };
+  const token2 = { id: TX_IDS[2], name: 'MyToken2', symbol: 'MT2' };
 
   await addToTokenTable(mysql, [
     { id: token1.id, name: token1.name, symbol: token1.symbol, transactions: 0 },
@@ -1401,7 +1402,30 @@ test('GET /wallet/tokens/token_id/details', async () => {
 
   expect(result.statusCode).toBe(400);
   expect(returnBody.success).toBe(false);
+  expect(returnBody.details).toMatchInlineSnapshot(`
+  Array [
+    Object {
+      "message": "\\"token_id\\" length must be at least 64 characters long",
+      "path": Array [
+        "token_id",
+      ],
+    },
+  ]
+  `);
+
+  const oldHathorTokenConfig = constants.HATHOR_TOKEN_CONFIG.uid;
+
+  constants.HATHOR_TOKEN_CONFIG.uid = TX_IDS[4];
+
+  event = makeGatewayEventWithAuthorizer('my-wallet', { token_id: constants.HATHOR_TOKEN_CONFIG.uid });
+  result = await getTokenDetails(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(400);
+  expect(returnBody.success).toBe(false);
   expect(returnBody.details).toStrictEqual([{ message: 'Invalid tokenId' }]);
+
+  constants.HATHOR_TOKEN_CONFIG.uid = oldHathorTokenConfig;
 });
 
 test('GET /wallet/utxos', async () => {


### PR DESCRIPTION
## Motivation

Since we now have htr on our token table, we should ignore it on `getTokenDetails` to prevent unnecessary database queries when it is requested

Fixes https://github.com/HathorNetwork/on-call-incidents/issues/87


### Acceptance Criteria
- Return an error when HTR is requested


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
