### PR TITLE
fix: parse firebase private key env

### DIFF
--- a/src/utils/pushnotification.utils.ts
+++ b/src/utils/pushnotification.utils.ts
@@ -119,8 +119,13 @@ const serviceAccount = {
 let firebaseInitialized = false;
 if (isPushNotificationEnabled()) {
   try {
+    serviceAccount.private_key = FIREBASE_PRIVATE_KEY
+      ? FIREBASE_PRIVATE_KEY.replace(/\\n/gm, '\n')
+      : undefined;
+
     console.log('serviceAccount.private_key', serviceAccount.private_key);
     console.log('FIREBASE_PRIVATE_KEY', FIREBASE_PRIVATE_KEY);
+
     fcmAdmin.initializeApp({
       credential: credential.cert(serviceAccount as ServiceAccount),
       projectId: FIREBASE_PROJECT_ID,

--- a/src/utils/pushnotification.utils.ts
+++ b/src/utils/pushnotification.utils.ts
@@ -119,6 +119,8 @@ const serviceAccount = {
 let firebaseInitialized = false;
 if (isPushNotificationEnabled()) {
   try {
+    console.log('serviceAccount.private_key', serviceAccount.private_key);
+    console.log('FIREBASE_PRIVATE_KEY', FIREBASE_PRIVATE_KEY);
     fcmAdmin.initializeApp({
       credential: credential.cert(serviceAccount as ServiceAccount),
       projectId: FIREBASE_PROJECT_ID,

--- a/tests/utils/pushnotification.utils.test.ts
+++ b/tests/utils/pushnotification.utils.test.ts
@@ -198,6 +198,19 @@ describe('PushNotificationUtils', () => {
       expect(logger.error).toHaveBeenLastCalledWith('[ALERT] env.FIREBASE_CLIENT_X509_CERT_URL can not be null or undefined.');
     });
 
+    it('FIREBASE_PRIVATE_KEY-IIFE', async () => {
+      expect.hasAssertions();
+
+      // load local env
+      // env variables are of type string, by assigning a boolean value we can test the error handling
+      process.env.FIREBASE_PRIVATE_KEY = true as unknown as string;
+
+      // reload module
+      const { PushNotificationUtils } = await import('@src/utils/pushnotification.utils');
+
+      expect(logger.error).toHaveBeenLastCalledWith('[ALERT] Error while parsing the env.FIREBASE_PRIVATE_KEY.');
+    });
+
     it('PUSH_ALLOWED_PROVIDERS', async () => {
       expect.hasAssertions();
 


### PR DESCRIPTION
### Acceptance Criteria
- fix: firebase env parse
- refactor: parse FIREBASE_PRIVATE_KEY

A direct deployment using the serverless API does not interfere with ENV values.
However, a deployment through the CI pipeline interferes with ENV values by escaping them.
To reverse this effect we need to restore its original value.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
