### PR TITLE
fix: cron expression by turning day-of-week undefined

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -679,7 +679,7 @@ functions:
     handler: src/db/cron.routines.cleanUnsentTxProposalsUtxos
     timeout: 60 # 1 minute
     events:
-      - schedule: cron(*/5 * * * * *) # run every 5 minutes
+      - schedule: cron(*/5 * * * ? *) # run every 5 minutes
     warmup:
       walletWarmer:
         enabled: false


### PR DESCRIPTION
### Acceptance Criteria
- turn day-of-week undefined on cleanUnsentTxProposalUtxos lambda's cron expression


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
