### PR TITLE
fix: using the latest block timestamp to detect if we have voided mem…

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1602,6 +1602,7 @@ export const getBlockByHeight = async (mysql: ServerlessMysql, height: number): 
     return {
       txId: results[0].tx_id as string,
       height: results[0].height as number,
+      timestamp: results[0].timestamp as number,
     };
   }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1582,6 +1582,33 @@ export const getLatestHeight = async (mysql: ServerlessMysql): Promise<number> =
 };
 
 /**
+ * Gets the best block from the database
+ *
+ * @param mysql - Database connection
+ *
+ * @returns The latest height
+ */
+export const getLatestBlockByHeight = async (mysql: ServerlessMysql): Promise<Block> => {
+  const results: DbSelectResult = await mysql.query(
+    `SELECT *
+       FROM \`transaction\`
+      WHERE \`version\` IN (?)
+      ORDER BY height DESC
+      LIMIT 1`, [BLOCK_VERSION],
+  );
+
+  if (results.length > 0) {
+    return {
+      txId: results[0].tx_id as string,
+      height: results[0].height as number,
+      timestamp: results[0].timestamp as number,
+    };
+  }
+
+  return null;
+};
+
+/**
  * Get block by height
  *
  * @param mysql - Database connection

--- a/src/mempool.ts
+++ b/src/mempool.ts
@@ -7,8 +7,7 @@
 
 import 'source-map-support/register';
 import {
-  getBlockByHeight,
-  getLatestHeight,
+  getLatestBlockByHeight,
   getMempoolTransactionsBeforeDate,
   updateTx,
 } from '@src/db';
@@ -19,7 +18,6 @@ import {
   fetchBlockHeight,
   closeDbConnection,
   getDbConnection,
-  getUnixTimestamp,
 } from '@src/utils';
 import createDefaultLogger from '@src/logger';
 import { addAlert } from '@src/utils/alerting.utils';
@@ -38,8 +36,7 @@ export const onHandleOldVoidedTxs = async (): Promise<void> => {
   const logger = createDefaultLogger();
 
   const VOIDED_TX_OFFSET: number = parseInt(process.env.VOIDED_TX_OFFSET, 10) * 60; // env is in minutes
-  const latestHeight: number = await getLatestHeight(mysql);
-  const bestBlock: Block = await getBlockByHeight(mysql, latestHeight);
+  const bestBlock: Block = await getLatestBlockByHeight(mysql);
   const bestBlockTimestamp = bestBlock.timestamp;
 
   const date: number = bestBlockTimestamp - VOIDED_TX_OFFSET;

--- a/src/types.ts
+++ b/src/types.ts
@@ -641,6 +641,7 @@ export interface DbTxOutput {
 export interface Block {
   txId: string;
   height: number;
+  timestamp: number;
 }
 
 // maybe use templates <TEvent = any, TResult = any>

--- a/tests/commons.test.ts
+++ b/tests/commons.test.ts
@@ -611,6 +611,7 @@ test('searchForLatestValidBlock should find the first voided block', async () =>
   const mockData: Block[] = TX_IDS.map((tx, index) => ({
     txId: tx,
     height: index,
+    timestamp: 0,
   }));
 
   for (let i = 0; i < mockData.length; i++) {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1171,6 +1171,10 @@ test('updateTx should add height to a tx', async () => {
 test('getLatestBlockByHeight', async () => {
   expect.hasAssertions();
 
+  // It should return null when the database has no blocks
+  const nullBestBlock: Block = await getLatestBlockByHeight(mysql);
+  expect(nullBestBlock).toBeNull();
+
   await addOrUpdateTx(mysql, 'block0', 0, 0, 0, 60);
   await addOrUpdateTx(mysql, 'block1', 1, 0, 0, 60);
   await addOrUpdateTx(mysql, 'block2', 2, 0, 0, 60);

--- a/tests/mempool.test.ts
+++ b/tests/mempool.test.ts
@@ -32,6 +32,8 @@ test('onHandleOldVoidedTxs', async () => {
     [TX_IDS[0], 1, 2, false, null, 60],
     [TX_IDS[1], 601, 2, false, null, 60],
     [TX_IDS[2], 1000, 2, false, null, 60],
+    // This should be our best block:
+    [TX_IDS[3], 20 * 60, 0, false, 10, 60],
   ];
 
   const utxos = [{
@@ -100,11 +102,8 @@ test('onHandleOldVoidedTxs', async () => {
   await addToTransactionTable(mysql, transactions);
   await addToUtxoTable(mysql, utxos);
 
-  const timestampSpy = jest.spyOn(Utils, 'getUnixTimestamp');
   const isTxVoidedSpy = jest.spyOn(Utils, 'isTxVoided');
 
-  // we need to mock current timestamp
-  timestampSpy.mockReturnValue(20 * 60);
   // and the check on the fullnode
   isTxVoidedSpy.mockReturnValue(Promise.resolve([true, {}]));
   // we also need to mock the offset
@@ -120,6 +119,8 @@ test('onHandleOldVoidedTxs should try to confirm the block by fetching the first
 
   const transactions = [
     [TX_IDS[0], 1, 2, false, null, 60],
+    // This is the block tx:
+    [TX_IDS[3], 15 * 60, 0, false, 10, 60],
   ];
 
   const utxos = [{
@@ -138,13 +139,10 @@ test('onHandleOldVoidedTxs should try to confirm the block by fetching the first
   await addToTransactionTable(mysql, transactions);
   await addToUtxoTable(mysql, utxos);
 
-  const timestampSpy = jest.spyOn(Utils, 'getUnixTimestamp');
   const isTxVoidedSpy = jest.spyOn(Utils, 'isTxVoided');
   const fetchBlockHeightSpy = jest.spyOn(Utils, 'fetchBlockHeight');
   const updateTxSpy = jest.spyOn(Db, 'updateTx');
 
-  // we need to mock current timestamp
-  timestampSpy.mockReturnValue(15 * 60);
   // also the fetchBlockHeight that goes to the fullnode
   fetchBlockHeightSpy.mockReturnValue(Promise.resolve([5, {}] as [number, any]));
   // also the check on the fullnode


### PR DESCRIPTION
Fixes https://github.com/HathorNetwork/on-call-incidents/issues/102

## Explanation

Currently, to detect transactions that got voided before getting confirmed by a block, we run a cronjob every 20 minutes to check if we have transactions without `height` on the database, if we do, we query the fullnode to check if it's really voided.

Since we are having larger block times because of the volatile hashrate on our mainnet, transactions are taking more than 20 minutes to get confirmed by a block and this is triggering alerts (false positives).

I changed it to check all transactions 20 minutes older than the latest block timestamp.

### Acceptance Criteria
- We should use the best block timestamp to query the database for mempool voided txs


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
