### PR TITLE
fix: clean voided tx before reinserting

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -99,25 +99,35 @@ export const checkTxWasVoided = async (mysql: ServerlessMysql, txId: string): Pr
  * handleReorg method voided this transaction
  *
  * @param mysql - Database connection
- * @param tx - The transaction to clear from database
+ * @param txId - The transaction to clear from database
  */
-export const cleanupVoidedTx = async (mysql: ServerlessMysql, tx: Tx): Promise<void> => {
+export const cleanupVoidedTx = async (mysql: ServerlessMysql, txId: string): Promise<void> => {
+  await mysql.query(
+    `DELETE FROM \`transaction\`
+      WHERE tx_id = ?
+        AND voided = true`,
+    [txId],
+  );
+
   await mysql.query(
     `DELETE FROM \`tx_output\`
-      WHERE tx_id = ?`,
-    [tx.txId],
+      WHERE tx_id = ?
+        AND voided = true`,
+    [txId],
   );
 
   await mysql.query(
     `DELETE FROM \`address_tx_history\`
-      WHERE tx_id = ?`,
-    [tx.txId],
+      WHERE tx_id = ?
+        AND voided = true`,
+    [txId],
   );
 
   await mysql.query(
     `DELETE FROM \`wallet_tx_history\`
-      WHERE tx_id = ?`,
-    [tx.txId],
+      WHERE tx_id = ?
+        AND voided = true`,
+    [txId],
   );
 };
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -80,7 +80,7 @@ export const checkTxWasVoided = async (mysql: ServerlessMysql, txId: string): Pr
 
   const addressTxHistory = results[0];
 
-  return addressTxHistory.voided as boolean;
+  return Boolean(addressTxHistory.voided);
 };
 
 export const cleanupVoidedTx = async (mysql: ServerlessMysql, tx: Tx): Promise<void> => {
@@ -101,7 +101,7 @@ export const cleanupVoidedTx = async (mysql: ServerlessMysql, tx: Tx): Promise<v
       WHERE tx_id = ?`,
     [tx.txId],
   );
-}
+};
 
 /**
  * Given an xpubkey, generate its addresses.

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -345,7 +345,7 @@ const _unsafeAddNewTx = async (_logger: Logger, tx: Transaction, now: number, bl
   const voidedTx = await checkTxWasVoided(mysql, txId);
 
   if (voidedTx) {
-    logger.info(`Transaction ${txId} received and was voided on databse`, {
+    logger.info(`Transaction ${txId} received and was voided on database`, {
       tx,
     });
     // this tx was already in the database in the past as voided and is now valid

--- a/src/txProcessor.ts
+++ b/src/txProcessor.ts
@@ -63,6 +63,7 @@ import createDefaultLogger from '@src/logger';
 import { NftUtils } from '@src/utils/nft.utils';
 import { PushNotificationUtils, isPushNotificationEnabled } from '@src/utils/pushnotification.utils';
 import { addAlert } from '@src/utils/alerting.utils';
+
 const mysql = getDbConnection();
 
 export const IGNORE_TXS = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -636,6 +636,7 @@ export interface DbTxOutput {
   spentBy?: string | null;
   txProposalId?: string;
   txProposalIndex?: number;
+  voided?: boolean | null;
 }
 
 export interface Block {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -139,7 +139,6 @@ import {
   checkPushDevicesTable,
   buildPushRegister,
   insertPushDevice,
-  addToTransactionTable,
   daysAgo,
 } from '@tests/utils';
 import { AddressTxHistoryTableEntry } from '@tests/types';
@@ -1808,15 +1807,6 @@ test('cleanupVoidedTx', async () => {
   const walletId = 'walletid';
   const tokenId = '00';
 
-  const tx: Tx = {
-    txId,
-    height: 15,
-    timestamp: 1,
-    version: 0,
-    voided: true,
-    weight: 60,
-  };
-
   await addToUtxoTable(mysql, [{
     txId,
     index: 0,
@@ -1828,6 +1818,7 @@ test('cleanupVoidedTx', async () => {
     heightlock: null,
     locked: false,
     spentBy: null,
+    voided: true,
   }]);
 
   await addToAddressTxHistoryTable(mysql, [{
@@ -1843,7 +1834,7 @@ test('cleanupVoidedTx', async () => {
     [walletId, txId, tokenId, 0, 0, true],
   ]);
 
-  await cleanupVoidedTx(mysql, tx);
+  await cleanupVoidedTx(mysql, txId);
 
   expect(await getTxOutput(mysql, txId, 0, false)).toBeNull();
   expect(await getWalletTxHistory(mysql, walletId, tokenId, 0, 10)).toHaveLength(0);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1818,7 +1818,7 @@ test('cleanupVoidedTx', async () => {
   };
 
   await addToUtxoTable(mysql, [{
-    txId: txId,
+    txId,
     index: 0,
     tokenId,
     address: addr1,
@@ -1832,7 +1832,7 @@ test('cleanupVoidedTx', async () => {
 
   await addToAddressTxHistoryTable(mysql, [{
     address: addr1,
-    txId: txId,
+    txId,
     tokenId,
     balance: 0,
     timestamp: 1,
@@ -1845,7 +1845,7 @@ test('cleanupVoidedTx', async () => {
 
   await cleanupVoidedTx(mysql, tx);
 
-  expect(await getTxOutput(mysql, txId, 0, false)).toStrictEqual(null);
+  expect(await getTxOutput(mysql, txId, 0, false)).toBeNull();
   expect(await getWalletTxHistory(mysql, walletId, tokenId, 0, 10)).toHaveLength(0);
   expect(await checkAddressTxHistoryTable(
     mysql,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -298,6 +298,11 @@ export const checkAddressTxHistoryTable = async (
     };
   }
 
+  // If we expect the table to be empty, we can return now.
+  if (totalResults === 0) {
+    return true;
+  }
+
   // now fetch the exact entry
   results = await mysql.query(
     `SELECT *

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -581,6 +581,7 @@ export const addToUtxoTable = async (
     entry.spentBy || null,
     entry.txProposalId || null,
     entry.txProposalIndex,
+    entry.voided || false,
   ]));
   await mysql.query(
     `INSERT INTO \`tx_output\`(
@@ -595,7 +596,8 @@ export const addToUtxoTable = async (
                  , \`locked\`
                  , \`spent_by\`
                  , \`tx_proposal\`
-                 , \`tx_proposal_index\`)
+                 , \`tx_proposal_index\`
+                 , \`voided\`)
      VALUES ?`,
     [payload],
   );


### PR DESCRIPTION
### Acceptance Criteria
- Should fix https://github.com/HathorNetwork/on-call-incidents/issues/64
- Should clean the database for voided `address_tx_history`, `wallet_tx_history` and `tx_output` rows


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
