### PR TITLE
fix: use node.js 14 in CodeBuild

### DIFF
--- a/.codebuild/buildspec.yml
+++ b/.codebuild/buildspec.yml
@@ -167,7 +167,7 @@ phases:
     #If you use the Ubuntu standard image 2.0 or later, you must specify runtime-versions.
     #If you specify runtime-versions and use an image other than Ubuntu standard image 2.0, the build fails.
     runtime-versions:
-      nodejs: 16
+      nodejs: 14
       # name: version
     commands:
       - npm i --also=dev


### PR DESCRIPTION
### Acceptance Criteria
- We should go back to node.js 14 in CodeBuild, because apparently node.js 16 is not available


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
