### PR TITLE
feat: added getAddressAtIndex method and API

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+if [[ $(type -t use_flake) != function ]]; then
+  echo "ERROR: use_flake function missing."
+  echo "Please update direnv to v2.30.0 or later."
+  exit 1
+fi
+
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ coverage
 
 # fcm account config
 **/fcm.config.json
+
+.direnv

--- a/README.md
+++ b/README.md
@@ -207,3 +207,16 @@ Sometimes, jest will use old cached js files, even after you modified the typesc
 ## Standard Operating Procedures
 
 Check it in [docs/SOP.md](docs/SOP.md)
+
+
+## Nix flakes
+
+## Using this project
+
+This project uses [Nix](https://nixos.org/) with [direnv](https://direnv.net/) to help with dependencies, including Node.js. To get started, you need to have Nix and direnv installed.
+
+1. Install [Nix](https://nixos.org/download.html) and [Direnv](https://direnv.net/docs/installation.html).
+2. Enable flake support in Nix: `nix-env -iA nixpkgs.nixUnstable`
+3. Allow direnv to work in your shell by running `direnv allow`
+
+Now, every time you enter the project directory, direnv will automatically activate the environment from flake.nix, including the specific version of Node.js specified there. When you leave the directory, it will deactivate. This ensures a consistent and isolated environment per project.

--- a/db/migrations/20230601151507-address_index_idx.js
+++ b/db/migrations/20230601151507-address_index_idx.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface) => {
+    await queryInterface.addIndex(
+      'address',
+      ['index'], {
+        name: 'address_index_idx',
+        fields: 'index',
+      },
+    );
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeIndex('address', 'address_index_idx');
+  },
+};

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,92 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1650201426,
+        "narHash": "sha256-u43Xf03ImFJWKLHddtjOpCJCHbuM0SQbb6FKR5NuFhk=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "cb76bc75a0ee81f2d8676fe681f268c48dbd380e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1643381941,
+        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1650194139,
+        "narHash": "sha256-kurZsqeOw5fpqA/Ig+8tHvbjwzs5P9AE6WUKOX1m6qM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bd4dffcdb7c577d74745bd1eff6230172bd176d5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "virtual environments";
+
+  inputs.devshell.url = "github:numtide/devshell";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, flake-utils, devshell, nixpkgs }:
+
+    flake-utils.lib.eachDefaultSystem (system: {
+      devShell =
+        let pkgs = import nixpkgs {
+          inherit system;
+
+          overlays = [ devshell.overlay ];
+        };
+        in
+        pkgs.devshell.mkShell {
+          packages = with pkgs; [
+            nixpkgs-fmt
+            nodejs-14_x
+          ];
+        };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,21 @@
+/*
+This flake.nix file creates a virtual environment with the desired dependencies 
+in a reproducible way using Nix and Nix flakes (https://nixos.wiki/wiki/Flakes)
+
+Flakes are a feature in Nix that allows you to specify the dependencies of your
+project in a declarative and reproducible manner. It allows for better isolation,
+reproducibility, and more reliable upgrades.
+
+`direnv` is an environment switcher for the shell. It knows how to hook into 
+multiple shells (like bash, zsh, fish, etc...) to load or unload environment
+variables depending on the current directory. This allows project-specific
+environment variables without cluttering the "~/.profile" file.
+
+This flake file creates a shell with nodejs v14.x installed and should work
+on macOs, linux and windows
+*/
 {
-  description = "virtual environments";
+  description = "Flake that installs Node.js 14.x via direnv";
 
   inputs.devshell.url = "github:numtide/devshell";
   inputs.flake-utils.url = "github:numtide/flake-utils";
@@ -16,7 +32,6 @@
         in
         pkgs.devshell.mkShell {
           packages = with pkgs; [
-            nixpkgs-fmt
             nodejs-14_x
           ];
         };

--- a/serverless.yml
+++ b/serverless.yml
@@ -314,6 +314,10 @@ functions:
           method: get
           cors: true
           authorizer: ${self:custom.authorizer.walletBearer}
+          request:
+            parameters:
+              paths:
+                index: false
     warmup:
       walletWarmer:
         enabled: true

--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -140,15 +140,8 @@ export const get: APIGatewayProxyHandler = middy(
     if (body.index) {
       const address: AddressInfo | null = await dbGetAddressAtIndex(mysql, walletId, body.index);
 
-      // If the walletId is valid and the wallet is ready we should have the address in our
-      // database. If we don't, alert.
       if (!address) {
-        await addAlert(
-          'Error on onNewTxRequest',
-          'Erroed on onNewTxRequest lambda',
-          Severity.MINOR,
-          { walletId, error: `getAddressAtIndex was called with a valid walletId but could not find the address at index ${body.index}` },
-        );
+        return closeDbAndGetError(mysql, ApiError.ADDRESS_NOT_FOUND);
       }
 
       response = {

--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -16,10 +16,9 @@ import {
   getWalletAddresses,
   getAddressAtIndex as dbGetAddressAtIndex,
 } from '@src/db';
-import { AddressInfo, AddressAtIndexRequest, Severity } from '@src/types';
+import { AddressInfo, AddressAtIndexRequest } from '@src/types';
 import { closeDbConnection, getDbConnection } from '@src/utils';
 import { walletIdProxyHandler } from '@src/commons';
-import { addAlert } from '@src/utils/alerting.utils';
 import middy from '@middy/core';
 import cors from '@middy/http-cors';
 

--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -108,7 +108,9 @@ export const checkMine: APIGatewayProxyHandler = middy(walletIdProxyHandler(asyn
 })).use(cors());
 
 /*
- * Get the addresses of a wallet
+ * Get the addresses of a wallet, allowing an index filter
+ * Notice: If the index filter is passed, it will only find addresses
+ * that are already in our database, this will not derive new addresses
  *
  * This lambda is called by API Gateway on GET /addresses
  */

--- a/src/api/addresses.ts
+++ b/src/api/addresses.ts
@@ -138,7 +138,7 @@ export const get: APIGatewayProxyHandler = middy(
 
     let response = null;
 
-    if (body.index) {
+    if ('index' in body) {
       const address: AddressInfo | null = await dbGetAddressAtIndex(mysql, walletId, body.index);
 
       if (!address) {

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -30,6 +30,7 @@ export enum ApiError {
   WALLET_ALREADY_LOADED = 'wallet-already-loaded',
   WALLET_MAX_RETRIES = 'wallet-max-retries',
   ADDRESS_NOT_IN_WALLET = 'address-not-in-wallet',
+  ADDRESS_NOT_FOUND = 'address-not-found',
   TX_OUTPUT_NOT_IN_WALLET = 'tx-output-not-in-wallet',
   TOKEN_NOT_FOUND = 'token-not-found',
   FORBIDDEN = 'forbidden',

--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -53,6 +53,7 @@ export const STATUS_CODE_TABLE = {
   [ApiError.TOKEN_NOT_FOUND]: 404,
   [ApiError.DEVICE_NOT_FOUND]: 404,
   [ApiError.TX_NOT_FOUND]: 404,
+  [ApiError.ADDRESS_NOT_FOUND]: 404,
 };
 
 /**

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,7 +7,7 @@
 import { strict as assert } from 'assert';
 import { ServerlessMysql } from 'serverless-mysql';
 import { get } from 'lodash';
-import { OkPacket } from 'mysql2';
+import { OkPacket } from 'mysql';
 import { constants } from '@hathor/wallet-lib';
 import {
   AddressIndexMap,

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -7,7 +7,7 @@
 import { strict as assert } from 'assert';
 import { ServerlessMysql } from 'serverless-mysql';
 import { get } from 'lodash';
-import { OkPacket } from 'mysql';
+import { OkPacket } from 'mysql2';
 import { constants } from '@hathor/wallet-lib';
 import {
   AddressIndexMap,
@@ -3156,4 +3156,39 @@ export const getUnsentTxProposals = async (
   );
 
   return result.map((row) => row.id);
+};
+
+/**
+ * Gets a specific address from an index and a walletId
+ *
+ * @param mysql - Database connection
+ * @param walletId - The wallet id to search for
+ * @param index - The address index to search for
+ *
+ * @returns An object containing the address, its index and the number of transactions
+ */
+export const getAddressAtIndex = async (
+  mysql: ServerlessMysql,
+  walletId: string,
+  index: number,
+): Promise<AddressInfo | null> => {
+  const addresses = await mysql.query<AddressInfo[]>(
+    `
+    SELECT \`address\`, \`index\`, \`transactions\`
+      FROM \`address\` pd
+     WHERE \`index\` = ?
+       AND \`wallet_id\` = ?
+     LIMIT 1`,
+    [walletId, index],
+  );
+
+  if (addresses.length <= 0) {
+    return null;
+  }
+
+  return {
+    address: addresses[0].address as string,
+    index: addresses[0].index as number,
+    transactions: addresses[0].transactions as number,
+  } as AddressInfo;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -709,6 +709,10 @@ export interface PushDelete {
   deviceId: string,
 }
 
+export interface AddressAtIndexRequest {
+  index: number,
+}
+
 export interface TxByIdRequest {
   txId: string,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -710,7 +710,7 @@ export interface PushDelete {
 }
 
 export interface AddressAtIndexRequest {
-  index: number,
+  index?: number,
 }
 
 export interface TxByIdRequest {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -175,11 +175,12 @@ test('GET /addresses', async () => {
 
   expect(result.statusCode).toBe(200);
   expect(returnBody.success).toBe(true);
-  expect(returnBody.addresses).toContainEqual({
+  expect(returnBody.addresses).toHaveLength(1);
+  expect(returnBody.addresses).toStrictEqual([{
     address: addresses[0].address,
     index: addresses[0].index,
     transactions: addresses[0].transactions,
-  });
+  }]);
 
   // we should receive ApiError.ADDRESS_NOT_FOUND if the address was not found
   event = makeGatewayEventWithAuthorizer('my-wallet', {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -180,6 +180,17 @@ test('GET /addresses', async () => {
     index: addresses[0].index,
     transactions: addresses[0].transactions,
   });
+
+  // we should receive ApiError.ADDRESS_NOT_FOUND if the address was not found
+  event = makeGatewayEventWithAuthorizer('my-wallet', {
+    index: '150',
+  });
+  result = await addressesGet(event, null, null) as APIGatewayProxyResult;
+  returnBody = JSON.parse(result.body as string);
+
+  expect(result.statusCode).toBe(404);
+  expect(returnBody.success).toBe(false);
+  expect(returnBody.error).toBe(ApiError.ADDRESS_NOT_FOUND);
 });
 
 test('GET /addresses/check_mine', async () => {

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -28,6 +28,7 @@ import {
   getTxOutput,
   getTransactionsById,
   getTxsAfterHeight,
+  getAddressAtIndex,
   initWalletBalance,
   initWalletTxHistory,
   markUtxosWithProposalId,
@@ -104,6 +105,7 @@ import {
   PushProvider,
   Severity,
   Block,
+  AddressInfo,
 } from '@src/types';
 import {
   closeDbConnection,
@@ -3613,5 +3615,41 @@ describe('Clear unsent txProposals utxos', () => {
     await cleanUnsentTxProposalsUtxos();
 
     expect(logger.debug).toHaveBeenCalledWith('No txproposals utxos to clean.');
+  });
+});
+
+describe('getAddressByIndex', () => {
+  it('should find a wallets address from its index', async () => {
+    expect.hasAssertions();
+
+    const address = 'address';
+    const walletId = 'walletId';
+    const index = 0;
+    const transactions = 0;
+
+    await addToAddressTable(mysql, [{
+      address,
+      index,
+      walletId,
+      transactions,
+    }]);
+
+    await expect(getAddressAtIndex(mysql, walletId, index))
+      .resolves
+      .toStrictEqual({
+        address,
+        index,
+        transactions,
+      });
+  });
+
+  it('should return null if an address couldnt be found', async () => {
+    expect.hasAssertions();
+
+    const walletId = 'walletId';
+
+    await expect(getAddressAtIndex(mysql, walletId, 1))
+      .resolves
+      .toBeNull();
   });
 });


### PR DESCRIPTION
### Motivation

Currently the `getAddressAtIndex` method in the wallet service facade is broken since it expects `this.seed` to have the seed loaded and we don't keep it in memory, so it derives an address from an empty Mnemonic:

https://github.com/HathorNetwork/hathor-wallet-lib/blob/652b94e72021dd11cd0372d3a5b750d9d83f0e29/src/wallet/wallet.ts#L991

We could ask for the user's PIN and use his seed to derive the address at an index, but that would also force us to also ask the PIN on the fullnode facade, which is something we don't want to do.

### Acceptance Criteria
- We should be able to fetch an address by its index
- We should include `flake.nix`, `flake.lock` and `direnv` files to setup a working nodejs14 environment using nix flakes


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
