### PR TITLE
refactor: using the hathor prefix on verifyMessage

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -334,7 +334,16 @@ export const verifySignature = (
   try {
     const message = String(timestamp).concat(walletId).concat(address);
 
-    return bitcoinMessage.verify(message, address, Buffer.from(signature, 'base64'));
+    return bitcoinMessage.verify(
+      message,
+      address,
+      Buffer.from(signature, 'base64'),
+      // Different from bitcore-lib, bitcoinjs-lib does not prefix the messagePrefix
+      // length on the message, so we need to do this by using a "End of Transmission
+      // Block" with the length (22) in hex (17). This is the same thing that is done
+      // for the default Bitcoin message (\u0018Bitcoin Signed Message:\n).
+      '\u0017Hathor Signed Message:\n',
+    );
   } catch (e) {
     // Since this will try to verify the signature passing user input, the verify method might
     // throw, we can just return false in this case.

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -54,6 +54,10 @@ import {
 } from '@tests/utils';
 import fullnode from '@src/fullnode';
 
+// Monkey patch bitcore-lib
+
+bitcore.Message.MAGIC_BYTES = Buffer.from('Hathor Signed Message:\n');
+
 const mysql = getDbConnection();
 
 beforeEach(async () => {


### PR DESCRIPTION
### Acceptance Criteria
- After https://github.com/HathorNetwork/hathor-wallet-lib/pull/546 is merged, we need to expect the new message prefix on the wallet-service to verify signatures


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
