### PR TITLE
docs: add PR templates for the new release process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,5 @@
-### Acceptance Criteria
-- Include here all things that this PR should solve
+Please go the the `Preview` tab and select the appropriate Pull Request template:
 
-
-### Security Checklist
-- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
+* [Feature Branch](?expand=1&template=feature_branch_pr_template.md) - Use this PR template when you are merging a feature branch into `master`
+* [Release Candidate](?expand=1&template=release_candidate_pr_template.md) - Use this PR template when you are merging `master` into `release-candidate`
+* [Release](?expand=1&template=release_pr_template.md) - Use this PR template when you are merging `release-candidate` into `release`

--- a/.github/PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature_branch_pr_template.md
@@ -1,0 +1,12 @@
+### Motivation
+
+What was the motivation for the changes in this PR?
+
+### Acceptance Criteria
+
+- Include here all things that this PR should solve
+
+### Checklist
+- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 
+- [ ] Make sure either the unit tests and/or the QA tests are capable of testing the new features
+- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

--- a/.github/PULL_REQUEST_TEMPLATE/release_candidate_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_candidate_pr_template.md
@@ -1,0 +1,8 @@
+# Changes
+
+Link here all the PRs that are included in this release candidate
+
+# Checklist
+
+- [ ] I've read and followed the release candidate process described in https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/wallet-service.md#release-candidate
+- [ ] I confirm this release candidate only includes production-ready changes

--- a/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release_pr_template.md
@@ -1,0 +1,12 @@
+# Changes
+
+Link here all the PRs that are included in this release
+
+# Release-candidates
+
+Link here the release-candidates that were deployed as part of this release
+
+# Checklist
+
+- [ ] I've read and followed the release process described in https://github.com/HathorNetwork/ops-tools/blob/master/docs/release-guides/wallet-service.md#stable-release
+- [ ] The QA process was run successfully during the tests of the corresponding release-candidate(s)


### PR DESCRIPTION
### Acceptance Criteria
- We should have multiple PR templates for the different kinds of PRs, as agreed in https://github.com/HathorNetwork/internal-issues/issues/153 (search for "PR templates")
- The solution is based on https://stackoverflow.com/a/75030350/3477266


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
