### PR TITLE
tests: using jest fake timers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  timers: 'fake',
   moduleNameMapper: {
     '^@src/(.*)$': '<rootDir>/src/$1',
     '^@tests/(.*)$': '<rootDir>/tests/$1',

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -1263,6 +1263,10 @@ test('storeTokenInformation and getTokenInformation', async () => {
 test('validateTokenTimestamps', async () => {
   expect.hasAssertions();
 
+  // We are using fake timers globally and this test expects the database to
+  // fill in updated_at, so we need real timers here.
+  jest.useRealTimers();
+
   const info = new TokenInfo('tokenId', 'tokenName', 'TKNS');
   storeTokenInformation(mysql, info.id, info.name, info.symbol);
   let result = await mysql.query('SELECT * FROM `token` WHERE `id` = ?', [info.id]);
@@ -1275,6 +1279,9 @@ test('validateTokenTimestamps', async () => {
 
   // After updating the entry, the created_at and updated_at must be different
   expect(result[0].created_at).not.toStrictEqual(result[0].updated_at);
+
+  // Go back to fake timers
+  jest.useFakeTimers();
 });
 
 test('getWalletSortedValueUtxos', async () => {

--- a/tests/mempool.test.ts
+++ b/tests/mempool.test.ts
@@ -97,10 +97,18 @@ test('onHandleOldVoidedTxs', async () => {
     [ADDRESSES[3], '00', 0, 0, null, 1, 0, 0, 400],
   ];
 
+  console.time('addToAddressBalanceTable');
   await addToAddressBalanceTable(mysql, addressEntries);
+  console.timeEnd('addToAddressBalanceTable');
+  console.time('addToAddressTxHistoryTable');
   await addToAddressTxHistoryTable(mysql, txHistory);
+  console.timeEnd('addToAddressTxHistoryTable');
+  console.time('addToTransactionTable');
   await addToTransactionTable(mysql, transactions);
+  console.timeEnd('addToTransactionTable');
+  console.time('addToUtxoTable');
   await addToUtxoTable(mysql, utxos);
+  console.timeEnd('addToUtxoTable');
 
   const isTxVoidedSpy = jest.spyOn(Utils, 'isTxVoided');
 
@@ -109,7 +117,9 @@ test('onHandleOldVoidedTxs', async () => {
   // we also need to mock the offset
   process.env.VOIDED_TX_OFFSET = '10'; // query will be on timestamp < 600
 
+  console.time('onHandleOldVoidedTxs');
   await onHandleOldVoidedTxs();
+  console.timeEnd('onHandleOldVoidedTxs');
 
   await expect(checkUtxoTable(mysql, 4, TX_IDS[0], 0, '00', ADDRESSES[0], 50, 0, null, null, false, null, true)).resolves.toBe(true);
 });

--- a/tests/mempool.test.ts
+++ b/tests/mempool.test.ts
@@ -97,18 +97,10 @@ test('onHandleOldVoidedTxs', async () => {
     [ADDRESSES[3], '00', 0, 0, null, 1, 0, 0, 400],
   ];
 
-  console.time('addToAddressBalanceTable');
   await addToAddressBalanceTable(mysql, addressEntries);
-  console.timeEnd('addToAddressBalanceTable');
-  console.time('addToAddressTxHistoryTable');
   await addToAddressTxHistoryTable(mysql, txHistory);
-  console.timeEnd('addToAddressTxHistoryTable');
-  console.time('addToTransactionTable');
   await addToTransactionTable(mysql, transactions);
-  console.timeEnd('addToTransactionTable');
-  console.time('addToUtxoTable');
   await addToUtxoTable(mysql, utxos);
-  console.timeEnd('addToUtxoTable');
 
   const isTxVoidedSpy = jest.spyOn(Utils, 'isTxVoided');
 
@@ -117,9 +109,7 @@ test('onHandleOldVoidedTxs', async () => {
   // we also need to mock the offset
   process.env.VOIDED_TX_OFFSET = '10'; // query will be on timestamp < 600
 
-  console.time('onHandleOldVoidedTxs');
   await onHandleOldVoidedTxs();
-  console.timeEnd('onHandleOldVoidedTxs');
 
   await expect(checkUtxoTable(mysql, 4, TX_IDS[0], 0, '00', ADDRESSES[0], 50, 0, null, null, false, null, true)).resolves.toBe(true);
 });
@@ -146,8 +136,12 @@ test('onHandleOldVoidedTxs should try to confirm the block by fetching the first
     spentBy: null,
   }];
 
+  console.time('addToTransactionTable');
   await addToTransactionTable(mysql, transactions);
+  console.timeEnd('addToTransactionTable');
+  console.time('addToUtxoTable');
   await addToUtxoTable(mysql, utxos);
+  console.timeEnd('addToUtxoTable');
 
   const isTxVoidedSpy = jest.spyOn(Utils, 'isTxVoided');
   const fetchBlockHeightSpy = jest.spyOn(Utils, 'fetchBlockHeight');
@@ -167,6 +161,8 @@ test('onHandleOldVoidedTxs should try to confirm the block by fetching the first
   // we also need to mock the offset
   process.env.VOIDED_TX_OFFSET = '10'; // query will be on timestamp < 5
 
+  console.time('onHandleOldVoidedTxs');
   await onHandleOldVoidedTxs();
+  console.timeEnd('onHandleOldVoidedTxs');
   expect(updateTxMock).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
### Motivation

Tests are failing on the [1.27.0+beta bump PR](https://github.com/HathorNetwork/hathor-wallet-service/pull/432/files) because of an off-by-one error when calculating time differences.

### Acceptance Criteria

- We should use jest fake timers to have more control over time on tests

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged 
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
